### PR TITLE
Fix postgres database driver detection

### DIFF
--- a/spark/so/config.go
+++ b/spark/so/config.go
@@ -102,7 +102,7 @@ type Config struct {
 
 // DatabaseDriver returns the database driver based on the database path.
 func (c *Config) DatabaseDriver() string {
-	if strings.HasPrefix(c.DatabasePath, "postgresql") {
+	if strings.HasPrefix(c.DatabasePath, "postgres") {
 		return "postgres"
 	}
 	return "sqlite3"


### PR DESCRIPTION
Postgres db urls can start with `postgres://` so this should be allowed