### PR TITLE
scripts: Add create_load_fund_wallet() make sure bitcoind wallet is setup correctly

### DIFF
--- a/run-everything.sh
+++ b/run-everything.sh
@@ -244,6 +244,37 @@ parse_bitcoin_config() {
     echo "$rpcuser $rpcpassword"
 }
 
+create_load_fund_wallet() {
+    local wallet_name=${1:-spark-wallet}
+    local bitcoin_cli="bitcoin-cli -rpcuser="$bitcoind_username" -rpcpassword="$bitcoind_password""
+
+    if ! $bitcoin_cli -rpcwallet="$wallet_name" getwalletinfo &>/dev/null; then
+        if $bitcoin_cli listwallets | grep -q "\"$wallet_name\""; then
+            echo "Loading existing wallet: $wallet_name"
+            $bitcoin_cli loadwallet "$wallet_name" &>/dev/null
+        else
+            echo "Creating new wallet: $wallet_name"
+            $bitcoin_cli createwallet "$wallet_name" &>/dev/null
+        fi
+    fi
+    echo "Wallet '$wallet_name' is ready"
+
+    # Check wallet balance
+    local balance=$($bitcoin_cli -rpcwallet="$wallet_name" getbalance)
+    echo "Current wallet balance: $balance BTC"
+
+    # Fund wallet if balance is 0 or very low
+    if (( $(echo "$balance < 1" | bc -l) )); then
+        echo "Wallet balance is low, funding with 101 blocks..."
+        local address=$($bitcoin_cli -rpcwallet="$wallet_name" getnewaddress)
+        $bitcoin_cli generatetoaddress 101 "$address" > /dev/null
+        local new_balance=$($bitcoin_cli -rpcwallet="$wallet_name" getbalance)
+        echo "Wallet funded! New balance: $new_balance BTC"
+    else
+        echo "Wallet has sufficient funds"
+    fi
+}
+
 run_bitcoind_tmux() {
     local run_dir=$1
     local wipe=$2
@@ -274,6 +305,11 @@ run_bitcoind_tmux() {
 
     # Send the command to tmux
     tmux send-keys -t "$session_name" "$cmd" C-m
+
+    sleep 5  # Give bitcoind time to start
+
+    # make sure the wallet is created, loaded, and funded
+    create_load_fund_wallet "spark-wallet"
 
     echo ""
     echo "================================================"


### PR DESCRIPTION
fixes parts of #79 

This PR adds functionality to `./run-everything.sh` to

1. Check if bitcoind has a wallet (note: after bitcoin core 0.21 bitcoind stopped [creating a wallet by default](https://github.com/bitcoin/bitcoin/blob/master/doc/managing-wallets.md#11-creating-the-wallet))
2. If it does not, create one called `spark-wallet`
3. Check `spark-wallet`'s balance
4. If it has less than 1 BTC in it, generate 101 blocks to fund it with the mining reward (note: only 1 block of mining reward will be available for spending in the wallet).

This gets more unit tests passing locally for me (unfortunately, i'm running into more instances of #90 ). I'll eventually get around to putting this into #71 to see what tests look like on CI. I think this can be merged independently though to make lives of [non-minikube users easier.](https://github.com/buildonspark/spark/issues/69#issuecomment-3554236203)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures a usable regtest wallet is available immediately after starting bitcoind.
> 
> - Adds `create_load_fund_wallet` to create/load `spark-wallet`, check balance, and `generatetoaddress` 101 blocks if balance < 1 BTC
> - Calls wallet setup after launching bitcoind in tmux (with a short `sleep` to allow startup)
> - Uses RPC creds from `bitcoin_regtest.conf` via `parse_bitcoin_config`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6559e713f26d046055d180cbf9ee7a5161437d11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->