### PR TITLE
Prevent CI lock file commit on main

### DIFF
--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: "Setup Node.js and Yarn"
         uses: ./public/actions/setup-node-yarn-install
         with:
-          cwd: "."
+          cwd: "./sdks/js"
           install-mode: "update-lock-only"
           # Since we are in update-lock-only mode the resulting yarn cache is much smaller and less useful
           # for the rest of the steps. But since this is the first step and the cache is restored for each
@@ -44,11 +44,17 @@ jobs:
       - name: "Commit and push changes if modified"
         id: sync-lock-file
         run: |
-          # On pushes to main, the checkout can be in a detached HEAD state and changes are initially
-          # unstaged. Use GitHub's ref and a working-tree diff against HEAD to detect modifications.
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]] && ! git diff --quiet HEAD; then
-            echo "Lock file must not be modified by CI on main branch."
-            exit 1;
+          # On pushes to main, CI must never update (or create) lock-related files.
+          # Use git status (includes untracked files) since `git diff` ignores new files.
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            if [[ -n "$(git status --porcelain)" ]]; then
+              echo "Lock file must not be modified by CI on main branch."
+              git status --porcelain
+              exit 1
+            fi
+
+            echo "VERIFIED_LOCK_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           git config --global user.name 'Lightspark Eng'
@@ -57,7 +63,7 @@ jobs:
           git diff-index --quiet HEAD || git commit -nm "CI update lock file for PR"
           git push
           echo "$(git rev-parse HEAD)"
-          echo "VERIFIED_LOCK_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "VERIFIED_LOCK_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   test:
     # Wait to see if the lock file should be updated before running checks:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens CI around lockfile handling and scopes updates to the JS SDK.
> 
> - Run `setup-node-yarn-install` with `cwd: ./sdks/js` (was `.`)
> - On pushes to `main`, replace diff check with stricter `git status --porcelain` guard; fail if any changes, otherwise set `VERIFIED_LOCK_COMMIT` and exit early
> - Quote `$GITHUB_OUTPUT` when exporting `VERIFIED_LOCK_COMMIT`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb95699c3a19e71aeea3456683ce5a91b37db590. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->