### PR TITLE
[gha] Simplify yarn setup jobs

### DIFF
--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -31,15 +31,16 @@ jobs:
           ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 2
 
-      - name: "Fail if JS lockfile would change on main"
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: "Setup Node.js and Yarn"
         uses: ./public/actions/setup-node-yarn-install
         with:
           cwd: "sdks/js"
           enable-corepack: "true"
-          # Fast lockfile-only refresh (skips link step / node_modules install).
           install-mode: "update-lock-only"
-          cache-prefix: "verify-js-lockfile-on-main"
+          # Since we are in update-lock-only mode the resulting yarn cache is much smaller and less useful
+          # for the rest of the steps. But since this is the first step and the cache is restored for each
+          # step in the workflow, they all get the same useless cache unless we set a different prefix here:
+          cache-prefix: "update-lock-file-for-prs"
 
       - name: "Fail if JS lockfile was modified on main"
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -50,18 +51,6 @@ jobs:
             git diff --stat -- sdks/js/yarn.lock
             exit 1
           fi
-
-      - name: "Setup Node.js and Yarn"
-        if: github.event_name == 'pull_request'
-        uses: ./public/actions/setup-node-yarn-install
-        with:
-          cwd: "sdks/js"
-          enable-corepack: "true"
-          install-mode: "update-lock-only"
-          # Since we are in update-lock-only mode the resulting yarn cache is much smaller and less useful
-          # for the rest of the steps. But since this is the first step and the cache is restored for each
-          # step in the workflow, they all get the same useless cache unless we set a different prefix here:
-          cache-prefix: "update-lock-file-for-prs"
 
       - name: "Commit and push changes if modified"
         id: sync-lock-file


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Streamlines the CI workflow for JS SDK lockfile handling.
> 
> - Consolidates `Setup Node.js and Yarn` into a single step for both PR and push runs with `install-mode: update-lock-only` and cache prefix `update-lock-file-for-prs`
> - Removes the duplicate PR-only setup step while retaining the main-branch guard that fails if `sdks/js/yarn.lock` would change
> - No changes to tests/build/release logic beyond this setup simplification
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f53b8b769e55ee77e3ce5bc2cb5acdad22ed378c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->