### PR TITLE
Revert workflow changes

### DIFF
--- a/.github/workflows/test-release-sync.yaml
+++ b/.github/workflows/test-release-sync.yaml
@@ -36,24 +36,15 @@ jobs:
         with:
           cwd: "sdks/js"
           enable-corepack: "true"
-          install-mode: "update-lock-only"
-          # Since we are in update-lock-only mode the resulting yarn cache is much smaller and less useful
+          # On main: use immutable mode to fail immediately if lockfile would change
+          # On PRs: update lockfile and commit if needed
+          install-mode: ${{ github.event_name == 'push' && 'install-prevent-lock-update' || 'update-lock-only' }}
+          # Since we may be in update-lock-only mode the resulting yarn cache is much smaller and less useful
           # for the rest of the steps. But since this is the first step and the cache is restored for each
           # step in the workflow, they all get the same useless cache unless we set a different prefix here:
           cache-prefix: "update-lock-file-for-prs"
 
-      - name: "Fail if JS lockfile was modified on main"
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          if ! git diff --quiet -- sdks/js/yarn.lock; then
-            echo "sdks/js/yarn.lock would be modified on main."
-            echo "This should be handled by the JS SDK lockfile maintenance workflow (opens a PR)."
-            git diff --stat -- sdks/js/yarn.lock
-            exit 1
-          fi
-
       - name: "Commit and push changes if modified"
-        id: sync-lock-file
         if: github.event_name == 'pull_request'
         run: |
           git config --global user.name 'Lightspark Eng'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change affecting CI behavior around `yarn.lock`; main risk is unexpected CI failures or missed lockfile updates due to install-mode logic.
> 
> **Overview**
> Adjusts `test-release-sync.yaml` lockfile handling so **pushes to `main` run yarn in immutable/no-lock-update mode** (failing fast if `sdks/js/yarn.lock` would change), while **PRs still run `update-lock-only` and auto-commit/push lockfile updates**.
> 
> Removes the separate “fail if lockfile modified on main” step, relying on the install mode to enforce lockfile stability on `main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b67949cb795cae9d8bb134a33361bdd5ffbc0aba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->