### PR TITLE
Fix typo in mise shell integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ mise trust
 mise install
 ```
 
-**Recommended**: Add [mise shell integration](https://mise.jdx.dev/getting-started.html#activate-mise) so that the mise environment will automatically activate when you are this repo, giving you access to all executables and environment variables. Otherwise you will need will need to either manually `mise activate [SHELL]` or run all commands with the `mise exec` prefix.
+**Recommended**: Add [mise shell integration](https://mise.jdx.dev/getting-started.html#activate-mise) so that the mise environment will automatically activate when you are in this repo, giving you access to all executables and environment variables. Otherwise you will need will need to either manually `mise activate [SHELL]` or run all commands with the `mise exec` prefix.
 
 ## pkg-config
 


### PR DESCRIPTION
Corrected a typo in the README regarding the mise environment activation instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no impact on runtime behavior.
> 
> **Overview**
> Updates `README.md` to fix a typo in the `mise` setup instructions ("when you are this repo" → "when you are in this repo").
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724eaf17e8953c7b5f5c660bf06118d7d2145205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->