### PR TITLE
Add Bare agent suspend balance repro

### DIFF
--- a/sdks/js/examples/spark-bare-app/auto-claim-static-deposit.js
+++ b/sdks/js/examples/spark-bare-app/auto-claim-static-deposit.js
@@ -5,18 +5,22 @@ import walletConfig, { getExampleWalletOptions } from "./wallet-config.js";
 
 async function autoclaimStaticDeposit(mnemonicInit, transactionId) {
   const options = getExampleWalletOptions(process.env, "REGTEST");
-  let { wallet } = await SparkWallet.initialize({
-    mnemonicOrSeed: mnemonicInit,
-    options,
-  });
-  const quote = await wallet.getClaimStaticDepositQuote(transactionId);
-  const claimResult = await wallet.claimStaticDeposit({
-    transactionId,
-    creditAmountSats: quote.creditAmountSats,
-    sspSignature: quote.signature,
-  });
-  await wallet.cleanupConnections();
-  return claimResult;
+  let wallet;
+  try {
+    const initialized = await SparkWallet.initialize({
+      mnemonicOrSeed: mnemonicInit,
+      options,
+    });
+    wallet = initialized.wallet;
+    const quote = await wallet.getClaimStaticDepositQuote(transactionId);
+    return await wallet.claimStaticDeposit({
+      transactionId,
+      creditAmountSats: quote.creditAmountSats,
+      sspSignature: quote.signature,
+    });
+  } finally {
+    await wallet?.cleanupConnections();
+  }
 }
 
 const args = process.argv.slice(2);

--- a/sdks/js/examples/spark-bare-app/create-lightning-invoice.js
+++ b/sdks/js/examples/spark-bare-app/create-lightning-invoice.js
@@ -4,16 +4,20 @@ import walletConfig, { getExampleWalletOptions } from "./wallet-config.js";
 
 async function createLightningInvoice(mnemonicInit, amountSats) {
   const options = getExampleWalletOptions(process.env, "REGTEST");
-  const { wallet } = await SparkWallet.initialize({
-    mnemonicOrSeed: mnemonicInit,
-    options,
-  });
+  let wallet;
+  try {
+    const initialized = await SparkWallet.initialize({
+      mnemonicOrSeed: mnemonicInit,
+      options,
+    });
+    wallet = initialized.wallet;
 
-  const invoice = await wallet.createLightningInvoice({
-    amountSats: Number(amountSats),
-  });
-  await wallet.cleanupConnections();
-  return invoice;
+    return await wallet.createLightningInvoice({
+      amountSats: Number(amountSats),
+    });
+  } finally {
+    await wallet?.cleanupConnections();
+  }
 }
 
 const args = process.argv.slice(2);

--- a/sdks/js/examples/spark-bare-app/get-or-create-wallet.js
+++ b/sdks/js/examples/spark-bare-app/get-or-create-wallet.js
@@ -5,18 +5,23 @@ import walletConfig, { getExampleWalletOptions } from "./wallet-config.js";
 
 async function getOrCreateWallet(mnemonicInit) {
   const options = getExampleWalletOptions(process.env, "REGTEST");
-  const { wallet, mnemonic } = await SparkWallet.initialize({
-    mnemonicOrSeed: mnemonicInit,
-    options,
-  });
-  const balance = await wallet.getBalance();
-  const sparkAddress = await wallet.getSparkAddress();
-  await wallet.cleanupConnections();
-  return {
-    mnemonic,
-    balance,
-    sparkAddress,
-  };
+  let wallet;
+  try {
+    const initialized = await SparkWallet.initialize({
+      mnemonicOrSeed: mnemonicInit,
+      options,
+    });
+    wallet = initialized.wallet;
+    const balance = await wallet.getBalance();
+    const sparkAddress = await wallet.getSparkAddress();
+    return {
+      mnemonic: initialized.mnemonic,
+      balance,
+      sparkAddress,
+    };
+  } finally {
+    await wallet?.cleanupConnections();
+  }
 }
 
 const args = process.argv.slice(2);

--- a/sdks/js/examples/spark-bare-app/get-static-deposit-address.js
+++ b/sdks/js/examples/spark-bare-app/get-static-deposit-address.js
@@ -5,13 +5,17 @@ import walletConfig, { getExampleWalletOptions } from "./wallet-config.js";
 
 async function getStaticDepositAddress(mnemonicInit) {
   const options = getExampleWalletOptions(process.env, "REGTEST");
-  let { wallet, mnemonic } = await SparkWallet.initialize({
-    mnemonicOrSeed: mnemonicInit,
-    options,
-  });
-  const staticDepositAddress = await wallet.getStaticDepositAddress();
-  await wallet.cleanupConnections();
-  return staticDepositAddress;
+  let wallet;
+  try {
+    const initialized = await SparkWallet.initialize({
+      mnemonicOrSeed: mnemonicInit,
+      options,
+    });
+    wallet = initialized.wallet;
+    return await wallet.getStaticDepositAddress();
+  } finally {
+    await wallet?.cleanupConnections();
+  }
 }
 
 const args = process.argv.slice(2);

--- a/sdks/js/examples/spark-bare-app/package.json
+++ b/sdks/js/examples/spark-bare-app/package.json
@@ -11,6 +11,7 @@
     "auto-claim-static-deposit": "node ./scripts/run-script.mjs auto-claim-static-deposit",
     "create-lightning-invoice": "node ./scripts/run-script.mjs create-lightning-invoice",
     "transfer": "node ./scripts/run-script.mjs transfer",
+    "repro:agent-suspend-balance": "node ./scripts/run-script.mjs repro-agent-suspend-balance",
     "run": "node ./scripts/run-script.mjs",
     "run:local": "cross-env NODE_ENV=development NETWORK=LOCAL ../../scripts/with-local-routing.sh node ./scripts/run-script.mjs",
     "run:mainnet": "cross-env NODE_ENV=production NETWORK=MAINNET node ./scripts/run-script.mjs",
@@ -21,6 +22,8 @@
     "@buildonspark/bare": "0.0.67",
     "@buildonspark/spark-sdk": "0.7.17",
     "bare": "^1.28.4",
+    "bare-http1": "^4.5.2",
+    "bare-https": "^3.0.0",
     "bare-runtime": "^1.28.4"
   },
   "devDependencies": {

--- a/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance-cleanup.log
+++ b/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance-cleanup.log
@@ -1,0 +1,26 @@
+$ WATCHDOG_MS=20000 NETWORK=MAINNET bare repro-agent-suspend-balance.js
+[2026-05-08T19:21:37.090Z] starting Bare agent suspend balance repro { cleanupConnections: true, network: 'MAINNET', watchdogMs: 20000 }
+[2026-05-08T19:21:37.815Z] wallet initialized
+[2026-05-08T19:21:37.935Z] initial balance resolved after 120ms {
+  balance: 0n,
+  satsBalance: { available: 0n, owned: 0n, incoming: 0n },
+  tokenBalances: Map(0) {}
+}
+[2026-05-08T19:21:37.936Z] agents suspended
+[2026-05-08T19:21:37.939Z] balance while agents already suspended rejected after 3ms SparkError: /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended [serverTraceId: 39961a9aa0d63b37fec142d383eca5a6, idPubKey: 03114fc8a14874bec79b734a44c8b7c36efb4d9dbce7ad51cc4e8cfe4746e6ba22, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-08T19:21:37.939Z] agents resumed
+[2026-05-08T19:21:37.939Z] same already-suspended balance promise after resume rejected after 0ms SparkError: /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended [serverTraceId: 39961a9aa0d63b37fec142d383eca5a6, idPubKey: 03114fc8a14874bec79b734a44c8b7c36efb4d9dbce7ad51cc4e8cfe4746e6ba22, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-08T19:21:37.940Z] agents suspended
+[2026-05-08T19:21:52.943Z] balance suspended while in flight rejected after 15003ms SparkError: /spark.SparkService/query_nodes UNKNOWN: Transport error: /spark.SparkService/query_nodes UNAVAILABLE: UNAVAILABLE: request timed out after 15000ms [serverTraceId: 39961a9aa0d63b37fec142d383eca5a6, idPubKey: 03114fc8a14874bec79b734a44c8b7c36efb4d9dbce7ad51cc4e8cfe4746e6ba22, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-08T19:21:52.943Z] agents resumed
+[2026-05-08T19:21:53.172Z] fresh balance after resume resolved after 229ms {
+  balance: 0n,
+  satsBalance: { available: 0n, owned: 0n, incoming: 0n },
+  tokenBalances: Map(0) {}
+}
+[2026-05-08T19:21:53.173Z] cleaning up wallet connections
+[2026-05-08T19:21:53.175Z] repro script completed
+real 16.38
+user 0.41
+sys 0.09
+exit_code=0

--- a/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance-direct-no-cleanup.log
+++ b/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance-direct-no-cleanup.log
@@ -1,0 +1,799 @@
+$ timeout 45 env WATCHDOG_MS=20000 CLEANUP_CONNECTIONS=0 NETWORK=MAINNET yarn workspace @buildonspark/spark-bare-app repro:agent-suspend-balance
+[2026-05-11T16:54:48.302Z] starting Bare agent suspend balance repro {
+  cleanupConnections: false,
+  enableSdkLogs: true,
+  network: 'MAINNET',
+  reproMode: 'direct-suspended',
+  sdkLogLevel: 'TRACE',
+  watchdogMs: 20000
+}
+2026-05-11T16:54:48.348Z [SparkWallet:029cabad] createClientsAndSyncWallet: initializing network=MAINNET coordinator=[path https://0.spark.lightspark.com/] signingOperators=3
+2026-05-11T16:54:48.348Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.348Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.348Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex x3 (+3ms total)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit createChannelWithTLS x3 (+0ms total)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit createGrpcClient x3 (+0ms total)
+2026-05-11T16:54:48.349Z [ConnectionManager:029cabad] exit createSparkAuthnGrpcConnection x3 (+0ms total)
+2026-05-11T16:54:48.350Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge starting request url=https://0.spark.lightspark.com/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:48.350Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge starting request url=https://spark-operator.breez.technology/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:48.350Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge starting request url=https://2.spark.flashnet.xyz/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:48.352Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:48.353Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:48.353Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:48.541Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Content-Type, X-Processing-Time-Ms, X-Trace-Id, Date, Vary, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"0ddf430a1babbb2f67ce501a6b253aea"}
+2026-05-11T16:54:48.541Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.541Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:48.541Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:48.542Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=122 chunk=1
+2026-05-11T16:54:48.542Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:48.542Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:48.542Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.542Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 2 chunks
+2026-05-11T16:54:48.542Z [BareHttpTransport:029cabad] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 2 chunks
+2026-05-11T16:54:48.544Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://0.spark.lightspark.com/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:48.544Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=229
+2026-05-11T16:54:48.559Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b528af35481d-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"0","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=140,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:48.559Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.559Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:48.559Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:48.559Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:48.559Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:48.559Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=143 chunk=1
+2026-05-11T16:54:48.559Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:48.559Z [BareHttpTransport:029cabad] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:48.560Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://2.spark.flashnet.xyz/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:48.560Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=229
+2026-05-11T16:54:48.584Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, X-Trace-Id, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"5ec266c463fd9b73d5c38bea247bf4ff"}
+2026-05-11T16:54:48.584Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.584Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=170 chunk=1
+2026-05-11T16:54:48.585Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:48.585Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response end observed by premature-close guard
+2026-05-11T16:54:48.585Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:48.585Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:48.585Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.585Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 2 chunks
+2026-05-11T16:54:48.585Z [BareHttpTransport:029cabad] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 2 chunks
+2026-05-11T16:54:48.585Z [ConnectionManager:029cabad] exit prepareMetadata x5 (+0ms total)
+2026-05-11T16:54:48.586Z [ConnectionManager:029cabad] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:48.586Z [ConnectionManager:029cabad] exit authenticate (+238ms)
+2026-05-11T16:54:48.586Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.586Z [ConnectionManager:029cabad] exit createChannelWithTLS (+0ms)
+2026-05-11T16:54:48.586Z [ConnectionManager:029cabad] exit createMiddleware (+0ms)
+2026-05-11T16:54:48.586Z [ConnectionManager:029cabad] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:48.586Z [ConnectionManager:029cabad] exit createGrpcClient (+0ms)
+2026-05-11T16:54:48.586Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+238ms)
+2026-05-11T16:54:48.588Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Content-Type, X-Processing-Time-Ms, X-Trace-Id, Vary, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"4422fef894ec987f129fae292a50e145"}
+2026-05-11T16:54:48.588Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.588Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:48.588Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:48.588Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:48.588Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:48.588Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=143 chunk=1
+2026-05-11T16:54:48.588Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:48.588Z [BareHttpTransport:029cabad] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:48.589Z [ConnectionManager:029cabad] exit createSparkClient (+238ms)
+2026-05-11T16:54:48.589Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://spark-operator.breez.technology/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:48.589Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=229
+2026-05-11T16:54:48.630Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Content-Type, X-Trace-Id, X-Processing-Time-Ms, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"4d1dca498d161abe72307e44f09543bc"}
+2026-05-11T16:54:48.630Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.630Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:48.630Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:48.630Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:48.630Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:48.630Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=191 chunk=1
+2026-05-11T16:54:48.631Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:48.631Z [BareHttpTransport:029cabad] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:48.631Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.631Z [ConnectionManager:029cabad] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:48.631Z [ConnectionManager:029cabad] exit authenticate (+283ms)
+2026-05-11T16:54:48.631Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.631Z [ConnectionManager:029cabad] exit createChannelWithTLS (+0ms)
+2026-05-11T16:54:48.631Z [ConnectionManager:029cabad] exit createMiddleware (+0ms)
+2026-05-11T16:54:48.631Z [ConnectionManager:029cabad] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:48.631Z [ConnectionManager:029cabad] exit createGrpcClient (+0ms)
+2026-05-11T16:54:48.631Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+283ms)
+2026-05-11T16:54:48.665Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b5299ad3481d-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"0","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=85,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:48.665Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.665Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:48.665Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:48.665Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:48.665Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:48.665Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=191 chunk=1
+2026-05-11T16:54:48.665Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:48.665Z [BareHttpTransport:029cabad] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit createSparkClient (+283ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit authenticate (+317ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit createChannelWithTLS (+0ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit createMiddleware (+0ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit createGrpcClient (+0ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+317ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit createSparkClient (+317ms)
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit createClients (+317ms)
+2026-05-11T16:54:48.665Z [SparkWallet:029cabad] setupBackgroundStream: subscribing to [path https://0.spark.lightspark.com/] retry=0
+2026-05-11T16:54:48.665Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.666Z [SparkWallet:029cabad] syncTokenOutputs: starting scope=all tokenCount=0
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+1ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit authenticate (+1ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit authenticate (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit createChannelWithTLS (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit createMiddleware (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit createMiddleware (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit createGrpcClient x2 (+0ms total)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit getOrCreateClientInternal x2 (+1ms total)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit createSparkTokenClient (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit createSparkStreamClient (+1ms)
+2026-05-11T16:54:48.666Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:48.666Z [SparkWallet:029cabad] setupBackgroundStream: subscribeToEvents returned async iterator
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit subscribeToEvents (+1ms)
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit authenticate (+1ms)
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:48.667Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs starting request url=https://0.spark.lightspark.com/spark_token.SparkTokenService/query_token_outputs responseStream=false
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit createSparkClient (+0ms)
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit authenticate (+0ms)
+2026-05-11T16:54:48.667Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.667Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_pending_transfers responseStream=false
+2026-05-11T16:54:48.667Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs wrote unary body bytes=46
+2026-05-11T16:54:48.668Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers wrote unary body bytes=48
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Content-Type, Vary, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"3","x-trace-id":"25314461f43fec7448332ccf9b1f4cb6"}
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response received status=200 responseStream=false
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs request close event
+2026-05-11T16:54:48.712Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response has no socket to guard
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=7 chunk=1
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response end event
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response close event
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response iterator completed after 2 chunks
+2026-05-11T16:54:48.712Z [BareHttpTransport:029cabad] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response iterator finally after 2 chunks
+2026-05-11T16:54:48.712Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.712Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+45.826041996479034ms)
+2026-05-11T16:54:48.712Z [TokenTransactionService:029cabad] exit fetchOwnedTokenOutputs (+46ms)
+2026-05-11T16:54:48.713Z [SparkWallet:029cabad] syncTokenOutputs: completed outputCount=0 tokenCount=0
+2026-05-11T16:54:48.713Z [LeafManager:029cabad] sync: Starting sync. Pre-sync: 0 leaves, available=0 owned=0 incoming=0
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getOrCreateClientInternal x7 (+0ms total)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit createSparkClient x7 (+0ms total)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex x7 (+0ms total)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.713Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.714Z [ConnectionManager:029cabad] exit makeChannelKey (+0ms)
+2026-05-11T16:54:48.714Z [ConnectionManager:029cabad] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:48.714Z [ConnectionManager:029cabad] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:48.714Z [ConnectionManager:029cabad] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:48.714Z [ConnectionManager:029cabad] exit createGrpcClient x3 (+0ms total)
+2026-05-11T16:54:48.714Z [ConnectionManager:029cabad] exit createSparkAuthnGrpcConnection x3 (+3ms total)
+2026-05-11T16:54:48.714Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge starting request url=https://0.spark.lightspark.com/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:48.714Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge starting request url=https://spark-operator.breez.technology/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:48.714Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge starting request url=https://2.spark.flashnet.xyz/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:48.714Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:48.714Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:48.714Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:48.758Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Content-Type, X-Processing-Time-Ms, X-Trace-Id, Vary, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"72d99caaae2d6084dd929e16e17e756f"}
+2026-05-11T16:54:48.758Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.758Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:48.758Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:48.758Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=122 chunk=1
+2026-05-11T16:54:48.759Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:48.759Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:48.759Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.759Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 2 chunks
+2026-05-11T16:54:48.759Z [BareHttpTransport:029cabad] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 2 chunks
+2026-05-11T16:54:48.759Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://0.spark.lightspark.com/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:48.759Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=230
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Trace-Id, X-Processing-Time-Ms, Date, Content-Type, Vary, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"b7e8374d4986da84e1ebe54fcb2c6e1f"}
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=122 chunk=1
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 2 chunks
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 2 chunks
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://spark-operator.breez.technology/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:48.760Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=230
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Trace-Id, Vary, Date, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"2caf9b9de7891cf53075237aad601e1a"}
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=170 chunk=1
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 2 chunks
+2026-05-11T16:54:48.801Z [BareHttpTransport:029cabad] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 2 chunks
+2026-05-11T16:54:48.802Z [ConnectionManager:029cabad] exit prepareMetadata x5 (+0ms total)
+2026-05-11T16:54:48.802Z [ConnectionManager:029cabad] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:48.802Z [ConnectionManager:029cabad] exit authenticate x5 (+445ms total)
+2026-05-11T16:54:48.802Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes starting request url=https://0.spark.lightspark.com/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:48.802Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_all_transfers responseStream=false
+2026-05-11T16:54:48.802Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_all_transfers responseStream=false
+2026-05-11T16:54:48.802Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_all_transfers responseStream=false
+2026-05-11T16:54:48.802Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_pending_transfers responseStream=false
+2026-05-11T16:54:48.802Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:48.802Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers wrote unary body bytes=57
+2026-05-11T16:54:48.802Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers wrote unary body bytes=63
+2026-05-11T16:54:48.802Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers wrote unary body bytes=59
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers wrote unary body bytes=48
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, Vary, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"d109bd67ac737c54136b318cdb2585ad"}
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=191 chunk=1
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:48.803Z [ConnectionManager:029cabad] exit getMonotonicTime x5 (+0ms total)
+2026-05-11T16:54:48.803Z [ConnectionManager:029cabad] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:48.803Z [ConnectionManager:029cabad] exit authenticate (+90ms)
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes starting request url=https://spark-operator.breez.technology/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:48.803Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:48.847Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b52a9e7d481d-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"0","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=109,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:48.847Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.847Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:48.847Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:48.847Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:48.847Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:48.847Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=143 chunk=1
+2026-05-11T16:54:48.847Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:48.847Z [BareHttpTransport:029cabad] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:48.848Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.848Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://2.spark.flashnet.xyz/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:48.848Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=229
+2026-05-11T16:54:48.854Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Content-Type, X-Processing-Time-Ms, X-Trace-Id, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"048d8d4bf12a2a49577016c37b51beb6"}
+2026-05-11T16:54:48.854Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:48.854Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:48.854Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.854Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:48.854Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:48.854Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:48.854Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:48.855Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:48.855Z [BareHttpTransport:029cabad] bareHttpTransport: #19 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:48.855Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+141.42733399569988ms)
+2026-05-11T16:54:48.856Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, X-Trace-Id, X-Processing-Time-Ms, Date, Content-Type, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"8","x-trace-id":"0c0cd334faf606944f62011da598aa2f"}
+2026-05-11T16:54:48.856Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:48.856Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes response chunk received bytes=16 chunk=1
+2026-05-11T16:54:48.857Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:48.857Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes response end observed by premature-close guard
+2026-05-11T16:54:48.857Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:48.857Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:48.857Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.857Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes response iterator completed after 2 chunks
+2026-05-11T16:54:48.857Z [BareHttpTransport:029cabad] bareHttpTransport: #14 /spark.SparkService/query_nodes response iterator finally after 2 chunks
+2026-05-11T16:54:48.857Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+143.64991699159145ms)
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"11","x-trace-id":"e393bb4c7264916732bc6f8f5ae04eb8"}
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response received status=200 responseStream=false
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers request close event
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response has no socket to guard
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response chunk received bytes=16 chunk=1
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response end event
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response close event
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response iterator completed after 2 chunks
+2026-05-11T16:54:48.865Z [BareHttpTransport:029cabad] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response iterator finally after 2 chunks
+2026-05-11T16:54:48.865Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+198.53587499260902ms)
+2026-05-11T16:54:48.865Z [SparkWallet:029cabad] claimTransfers: found pendingTransfers=0
+2026-05-11T16:54:48.865Z [SparkWallet:029cabad] claimTransfers: found 0 pending transfers
+2026-05-11T16:54:48.865Z [SparkWallet:029cabad] claimTransfers: completed claimed=0 attempted=0
+2026-05-11T16:54:48.865Z [SparkWallet:029cabad] claimTransfers: completed. Claimed 0 of 0 attempted
+2026-05-11T16:54:48.865Z [SparkWallet:029cabad] setupBackgroundStream: claimTransfers completed claimedTransfers=0
+2026-05-11T16:54:48.865Z [SparkWallet:029cabad] syncTokenOutputs: starting scope=all tokenCount=0
+2026-05-11T16:54:48.866Z [ConnectionManager:029cabad] exit getMonotonicTime x6 (+0ms total)
+2026-05-11T16:54:48.866Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:48.866Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:48.866Z [ConnectionManager:029cabad] exit createSparkTokenClient (+0ms)
+2026-05-11T16:54:48.866Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.866Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.866Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.866Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:48.866Z [ConnectionManager:029cabad] exit authenticate (+0ms)
+2026-05-11T16:54:48.866Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs starting request url=https://0.spark.lightspark.com/spark_token.SparkTokenService/query_token_outputs responseStream=false
+2026-05-11T16:54:48.866Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs wrote unary body bytes=46
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, X-Trace-Id, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"12","x-trace-id":"1611c4a658319ca374a7fb44c44f1d3c"}
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs response received status=200 responseStream=false
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=7 chunk=1
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs response end event
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs response end observed by premature-close guard
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs response close event
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs request close event
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs response iterator completed after 2 chunks
+2026-05-11T16:54:48.923Z [BareHttpTransport:029cabad] bareHttpTransport: #21 /spark_token.SparkTokenService/query_token_outputs response iterator finally after 2 chunks
+2026-05-11T16:54:48.923Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+57.785291999578476ms)
+2026-05-11T16:54:48.923Z [TokenTransactionService:029cabad] exit fetchOwnedTokenOutputs (+58ms)
+2026-05-11T16:54:48.923Z [SparkWallet:029cabad] syncTokenOutputs: completed outputCount=0 tokenCount=0
+2026-05-11T16:54:48.924Z [ConnectionManager:029cabad] gRPC /spark.SparkService/subscribe_to_events [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:48.924Z [ConnectionManager:029cabad] exit getMonotonicTime x4 (+0ms total)
+2026-05-11T16:54:48.924Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:48.924Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:48.924Z [ConnectionManager:029cabad] exit authenticate (+0ms)
+2026-05-11T16:54:48.924Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events starting request url=https://0.spark.lightspark.com/spark.SparkService/subscribe_to_events responseStream=true
+2026-05-11T16:54:48.924Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events wrote unary body bytes=40
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b52b6970481d-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"X-Processing-Time-Ms, Date, Content-Type, Vary, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"0","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=101,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=191 chunk=1
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #20 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:48.969Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.969Z [ConnectionManager:029cabad] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:48.969Z [ConnectionManager:029cabad] exit authenticate (+256ms)
+2026-05-11T16:54:48.969Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.969Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes starting request url=https://2.spark.flashnet.xyz/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:48.970Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:48.970Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Content-Type, Vary, Date, grpc-status, grpc-message","vary":"Origin"}
+2026-05-11T16:54:48.970Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response received status=200 responseStream=true
+2026-05-11T16:54:48.970Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response socket unref applied
+2026-05-11T16:54:48.970Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.970Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=1
+2026-05-11T16:54:48.970Z [SparkWallet:029cabad] setupBackgroundStream: stream event received type=connected
+2026-05-11T16:54:48.970Z [SparkWallet:029cabad] setupBackgroundStream: connected
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Processing-Time-Ms, Date, Content-Type, X-Trace-Id, Vary, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"4cb10a2facb2dcefbe6c59afbefc4cf8"}
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers response received status=200 responseStream=false
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers request close event
+2026-05-11T16:54:48.980Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers response has no socket to guard
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers response chunk received bytes=16 chunk=1
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers response end event
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers response close event
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers response iterator completed after 2 chunks
+2026-05-11T16:54:48.980Z [BareHttpTransport:029cabad] bareHttpTransport: #15 /spark.SparkService/query_all_transfers response iterator finally after 2 chunks
+2026-05-11T16:54:48.980Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.980Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+266.90433399379253ms)
+2026-05-11T16:54:48.980Z [TransferService:029cabad] exit queryPendingTransfers (+198ms)
+2026-05-11T16:54:48.980Z [TransferService:029cabad] exit queryAllTransfers (+267ms)
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"9ae18bb35d1ebe457769e516c5500dd1"}
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers response received status=200 responseStream=false
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers request close event
+2026-05-11T16:54:48.989Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers response has no socket to guard
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers response chunk received bytes=16 chunk=1
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers response end event
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers response close event
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers response iterator completed after 2 chunks
+2026-05-11T16:54:48.989Z [BareHttpTransport:029cabad] bareHttpTransport: #18 /spark.SparkService/query_pending_transfers response iterator finally after 2 chunks
+2026-05-11T16:54:48.989Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.989Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+275.7381249964237ms)
+2026-05-11T16:54:48.989Z [TransferService:029cabad] exit queryPrimarySwapTransfers (+267ms)
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:48 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"1b60bbc657ec2ee7704456a3a646c133"}
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response received status=200 responseStream=false
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers request close event
+2026-05-11T16:54:48.990Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response has no socket to guard
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response chunk received bytes=16 chunk=1
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response end event
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response close event
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response chunk received bytes=21 chunk=2
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response iterator completed after 2 chunks
+2026-05-11T16:54:48.990Z [BareHttpTransport:029cabad] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response iterator finally after 2 chunks
+2026-05-11T16:54:48.990Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:48.990Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+276.6682090014219ms)
+2026-05-11T16:54:48.990Z [TransferService:029cabad] exit queryPendingTransfers (+276ms)
+2026-05-11T16:54:48.990Z [TransferService:029cabad] exit queryAllTransfers (+277ms)
+2026-05-11T16:54:49.011Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Trace-Id, X-Processing-Time-Ms, Vary, Date, Content-Type, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"8","x-trace-id":"60a5e5b73d7ff0de5429f37c4a2233f7"}
+2026-05-11T16:54:49.012Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response received status=200 responseStream=false
+2026-05-11T16:54:49.012Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers request close event
+2026-05-11T16:54:49.012Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.012Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response has no socket to guard
+2026-05-11T16:54:49.012Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response chunk received bytes=16 chunk=1
+2026-05-11T16:54:49.012Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response end event
+2026-05-11T16:54:49.012Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response close event
+2026-05-11T16:54:49.012Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response chunk received bytes=21 chunk=2
+2026-05-11T16:54:49.012Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response iterator completed after 2 chunks
+2026-05-11T16:54:49.012Z [BareHttpTransport:029cabad] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response iterator finally after 2 chunks
+2026-05-11T16:54:49.012Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.012Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+298.45374999940395ms)
+2026-05-11T16:54:49.012Z [TransferService:029cabad] exit queryPendingOutgoingTransfers (+277ms)
+2026-05-11T16:54:49.012Z [TransferService:029cabad] exit queryAllTransfers (+299ms)
+2026-05-11T16:54:49.012Z [TransferService:029cabad] exit queryCounterSwapTransfers (+299ms)
+2026-05-11T16:54:49.074Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b52c3c00481d-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"X-Processing-Time-Ms, Vary, Date, Content-Type, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"2","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=85,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:49.074Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:49.074Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:49.074Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.074Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:49.074Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:49.074Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:49.074Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:49.075Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:49.075Z [BareHttpTransport:029cabad] bareHttpTransport: #23 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:49.075Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.075Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+361.346582993865ms)
+2026-05-11T16:54:49.075Z [LeafManager:029cabad] sync: Fetched: 0 leaves, 0 pending swaps, 0 outgoing, 0 incoming
+2026-05-11T16:54:49.075Z [LeafManager:029cabad] sync: Complete. Post-sync: leaves=0 available=0 owned=0 incoming=0 statusCounts=AVAILABLE=0 LOCAL_LOCKED=0 OUTGOING=0 SWAP_PENDING=0 INCOMING=0 SPENT=0
+2026-05-11T16:54:49.076Z [LeafManager:029cabad] autoOptimizeIfNeeded: No optimization needed for 0 leaves
+2026-05-11T16:54:49.076Z [SparkWallet:029cabad] createClientsAndSyncWallet: initial wallet sync complete
+2026-05-11T16:54:49.076Z [SparkWallet:029cabad] exit initialize (+771ms)
+[2026-05-11T16:54:49.076Z] wallet initialized
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit getOrCreateClientInternal x3 (+0ms total)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit createSparkClient x3 (+0ms total)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.076Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.077Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex x3 (+2ms total)
+2026-05-11T16:54:49.077Z [ConnectionManager:029cabad] exit authenticate x3 (+2ms total)
+2026-05-11T16:54:49.077Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.077Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes starting request url=https://0.spark.lightspark.com/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:49.077Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.077Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes starting request url=https://spark-operator.breez.technology/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:49.077Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.077Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes starting request url=https://2.spark.flashnet.xyz/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:49.077Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:49.077Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:49.077Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:49.125Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"575a791b69d1645146974544cb483d9e"}
+2026-05-11T16:54:49.125Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:49.125Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:49.125Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.125Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:49.125Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:49.125Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:49.125Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:49.125Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:49.125Z [BareHttpTransport:029cabad] bareHttpTransport: #25 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:49.125Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.125Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+48.98829199373722ms)
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Content-Type, X-Trace-Id, X-Processing-Time-Ms, Vary, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"bd053583c39f956fc61f5853b293088e"}
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:49.126Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes response chunk received bytes=16 chunk=1
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes response chunk received bytes=21 chunk=2
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes response iterator completed after 2 chunks
+2026-05-11T16:54:49.126Z [BareHttpTransport:029cabad] bareHttpTransport: #24 /spark.SparkService/query_nodes response iterator finally after 2 chunks
+2026-05-11T16:54:49.126Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.126Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+49.30937500298023ms)
+2026-05-11T16:54:49.191Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b52cde58481d-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"1","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=94,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:49.191Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:49.191Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:49.191Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.191Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:49.191Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:49.191Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:49.191Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:49.191Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:49.191Z [BareHttpTransport:029cabad] bareHttpTransport: #26 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:49.191Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.191Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+114.71549999713898ms)
+2026-05-11T16:54:49.191Z [SparkWallet:029cabad] syncTokenOutputs: starting scope=all tokenCount=0
+2026-05-11T16:54:49.192Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.192Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:49.192Z [ConnectionManager:029cabad] exit createSparkTokenClient (+0ms)
+2026-05-11T16:54:49.192Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.192Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.192Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.192Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:49.192Z [ConnectionManager:029cabad] exit authenticate (+0ms)
+2026-05-11T16:54:49.192Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.192Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs starting request url=https://0.spark.lightspark.com/spark_token.SparkTokenService/query_token_outputs responseStream=false
+2026-05-11T16:54:49.192Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs wrote unary body bytes=46
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Content-Type, X-Processing-Time-Ms, X-Trace-Id, Vary, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"ce0e423ac7846c58f1444aab625f18c2"}
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response received status=200 responseStream=false
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs request close event
+2026-05-11T16:54:49.239Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response has no socket to guard
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=7 chunk=1
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response end event
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response close event
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=21 chunk=2
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response iterator completed after 2 chunks
+2026-05-11T16:54:49.239Z [BareHttpTransport:029cabad] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response iterator finally after 2 chunks
+2026-05-11T16:54:49.239Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.239Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+47.36745800077915ms)
+2026-05-11T16:54:49.239Z [TokenTransactionService:029cabad] exit fetchOwnedTokenOutputs (+48ms)
+2026-05-11T16:54:49.239Z [SparkWallet:029cabad] syncTokenOutputs: completed outputCount=0 tokenCount=0
+2026-05-11T16:54:49.239Z [SparkWallet:029cabad] exit getBalance (+163ms)
+[2026-05-11T16:54:49.239Z] initial balance resolved after 163ms {
+  balance: 0n,
+  satsBalance: { available: 0n, owned: 0n, incoming: 0n },
+  tokenBalances: Map(0) {}
+}
+[2026-05-11T16:54:49.240Z] agents suspended
+[2026-05-11T16:54:49.240Z] calling wallet.getBalance() directly while agents are suspended
+2026-05-11T16:54:49.240Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events socket close observed by premature-close guard
+2026-05-11T16:54:49.241Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events forcing response teardown after socket close
+2026-05-11T16:54:49.241Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.241Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.241Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events request close event
+2026-05-11T16:54:49.241Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response error event: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:49.241Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response close event
+2026-05-11T16:54:49.241Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.241Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response iterator error after 1 chunks: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:49.244Z [BareHttpTransport:029cabad] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response iterator finally after 1 chunks
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit getOrCreateClientInternal x3 (+0ms total)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit createSparkClient x3 (+9ms total)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex x3 (+0ms total)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] gRPC /spark.SparkService/subscribe_to_events [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> error (+320.6194999963045ms): /spark.SparkService/subscribe_to_events UNKNOWN: Transport error: /spark.SparkService/subscribe_to_events UNAVAILABLE: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit authenticate x3 (+0ms total)
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] error handleMiddlewareError (+0ms): /spark.SparkService/subscribe_to_events UNKNOWN: Transport error: /spark.SparkService/subscribe_to_events UNAVAILABLE: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.244Z [BareHttpTransport:029cabad] bareHttpTransport: #28 /spark.SparkService/query_nodes starting request url=https://0.spark.lightspark.com/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.244Z [BareHttpTransport:029cabad] bareHttpTransport: #29 /spark.SparkService/query_nodes starting request url=https://spark-operator.breez.technology/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:49.244Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.244Z [BareHttpTransport:029cabad] bareHttpTransport: #30 /spark.SparkService/query_nodes starting request url=https://2.spark.flashnet.xyz/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:49.244Z [SparkWallet:029cabad] setupBackgroundStream: stream iterator threw: /spark.SparkService/subscribe_to_events UNKNOWN: Transport error: /spark.SparkService/subscribe_to_events UNAVAILABLE: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:49.244Z [SparkWallet:029cabad] setupBackgroundStream: error: /spark.SparkService/subscribe_to_events UNKNOWN: Transport error: /spark.SparkService/subscribe_to_events UNAVAILABLE: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events; retrying in 1000ms (attempt=1)
+2026-05-11T16:54:49.245Z [BareHttpTransport:029cabad] bareHttpTransport: #28 /spark.SparkService/query_nodes request setup failed: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:49.245Z [BareHttpTransport:029cabad] bareHttpTransport: #29 /spark.SparkService/query_nodes request setup failed: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:49.245Z [BareHttpTransport:029cabad] bareHttpTransport: #30 /spark.SparkService/query_nodes request setup failed: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:49.245Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.245Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> error (+1.033041000366211ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:49.245Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.245Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> error (+1.0134170055389404ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:49.245Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.245Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> error (+1.0078330039978027ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:49.245Z [ConnectionManager:029cabad] error handleMiddlewareError (+0ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:49.245Z [ConnectionManager:029cabad] error handleMiddlewareError (+0ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:49.245Z [ConnectionManager:029cabad] error handleMiddlewareError (+0ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:49.246Z [SparkWallet:029cabad] error getBalance (+6ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended [serverTraceId: ce0e423ac7846c58f1444aab625f18c2, idPubKey: 029cabad87304364d638b5434203699ad3668bf583ad3b7da47e06149b078d412a, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-11T16:54:49.246Z] direct suspended balance rejected SparkError: /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended [serverTraceId: ce0e423ac7846c58f1444aab625f18c2, idPubKey: 029cabad87304364d638b5434203699ad3668bf583ad3b7da47e06149b078d412a, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-11T16:54:49.246Z] agents resumed
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getOrCreateClientInternal x3 (+0ms total)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit createSparkClient x3 (+0ms total)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex x3 (+0ms total)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit authenticate x3 (+0ms total)
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.246Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes starting request url=https://0.spark.lightspark.com/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.246Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes starting request url=https://spark-operator.breez.technology/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:49.246Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.246Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes starting request url=https://2.spark.flashnet.xyz/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:49.246Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:49.246Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:49.246Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:49.423Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Content-Type, Vary, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"41bdfdeb4d4fb7b48ab4fda969290a5c"}
+2026-05-11T16:54:49.423Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:49.423Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:49.423Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.423Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:49.423Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:49.423Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:49.423Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:49.423Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:49.423Z [BareHttpTransport:029cabad] bareHttpTransport: #32 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:49.423Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.423Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+177.41520799696445ms)
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"a427ba9e5dbe8a95e872732722a2225d"}
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:49.426Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes response chunk received bytes=16 chunk=1
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes response chunk received bytes=21 chunk=2
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes response iterator completed after 2 chunks
+2026-05-11T16:54:49.426Z [BareHttpTransport:029cabad] bareHttpTransport: #31 /spark.SparkService/query_nodes response iterator finally after 2 chunks
+2026-05-11T16:54:49.426Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.426Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+180.31954200565815ms)
+2026-05-11T16:54:49.492Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b52e3e63f8cf-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"1","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=181,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:49.492Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:49.492Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.493Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:49.493Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:49.493Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:49.493Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:49.493Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:49.493Z [BareHttpTransport:029cabad] bareHttpTransport: #33 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+247.0547080039978ms)
+2026-05-11T16:54:49.493Z [SparkWallet:029cabad] syncTokenOutputs: starting scope=all tokenCount=0
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit createSparkTokenClient (+0ms)
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit authenticate (+0ms)
+2026-05-11T16:54:49.493Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.493Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs starting request url=https://0.spark.lightspark.com/spark_token.SparkTokenService/query_token_outputs responseStream=false
+2026-05-11T16:54:49.493Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs wrote unary body bytes=46
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response received status=200 headers={"date":"Mon, 11 May 2026 16:54:49 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Content-Type, X-Trace-Id, X-Processing-Time-Ms, Vary, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"2","x-trace-id":"b969940200a280d969f1e48c87ab6b05"}
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response received status=200 responseStream=false
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs request close event
+2026-05-11T16:54:49.546Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response has no socket to guard
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=7 chunk=1
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response end event
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response close event
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=21 chunk=2
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response iterator completed after 2 chunks
+2026-05-11T16:54:49.546Z [BareHttpTransport:029cabad] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response iterator finally after 2 chunks
+2026-05-11T16:54:49.546Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:49.546Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+52.68283300101757ms)
+2026-05-11T16:54:49.546Z [TokenTransactionService:029cabad] exit fetchOwnedTokenOutputs (+53ms)
+2026-05-11T16:54:49.546Z [SparkWallet:029cabad] syncTokenOutputs: completed outputCount=0 tokenCount=0
+2026-05-11T16:54:49.546Z [SparkWallet:029cabad] exit getBalance (+300ms)
+[2026-05-11T16:54:49.546Z] fresh balance after direct suspended call resolved after 300ms {
+  balance: 0n,
+  satsBalance: { available: 0n, owned: 0n, incoming: 0n },
+  tokenBalances: Map(0) {}
+}
+[2026-05-11T16:54:49.546Z] skipping wallet cleanup; process should exit only if no SDK handles keep it alive
+[2026-05-11T16:54:49.546Z] repro script completed
+2026-05-11T16:54:50.246Z [SparkWallet:029cabad] setupBackgroundStream: stream loop iteration finished retryCount=1 aborted=false
+2026-05-11T16:54:50.246Z [SparkWallet:029cabad] setupBackgroundStream: subscribing to [path https://0.spark.lightspark.com/] retry=1
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit createSparkStreamClient (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit subscribeToEvents (+0ms)
+2026-05-11T16:54:50.246Z [SparkWallet:029cabad] setupBackgroundStream: subscribeToEvents returned async iterator
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit createSparkClient (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit authenticate (+0ms)
+2026-05-11T16:54:50.246Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.246Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_pending_transfers responseStream=false
+2026-05-11T16:54:50.246Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers wrote unary body bytes=48
+2026-05-11T16:54:50.293Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:50 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, X-Trace-Id, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"8","x-trace-id":"3cfa5fdceef3fb2d058fe592f94a0c00"}
+2026-05-11T16:54:50.293Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers response received status=200 responseStream=false
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers response chunk received bytes=16 chunk=1
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers response end event
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers response end observed by premature-close guard
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers response close event
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers request close event
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers response chunk received bytes=21 chunk=2
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers response iterator completed after 2 chunks
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #35 /spark.SparkService/query_pending_transfers response iterator finally after 2 chunks
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+48.13808299601078ms)
+2026-05-11T16:54:50.294Z [TransferService:029cabad] exit queryPendingTransfers (+48ms)
+2026-05-11T16:54:50.294Z [SparkWallet:029cabad] claimTransfers: found pendingTransfers=0
+2026-05-11T16:54:50.294Z [SparkWallet:029cabad] claimTransfers: found 0 pending transfers
+2026-05-11T16:54:50.294Z [SparkWallet:029cabad] claimTransfers: completed claimed=0 attempted=0
+2026-05-11T16:54:50.294Z [SparkWallet:029cabad] claimTransfers: completed. Claimed 0 of 0 attempted
+2026-05-11T16:54:50.294Z [SparkWallet:029cabad] setupBackgroundStream: claimTransfers completed claimedTransfers=0
+2026-05-11T16:54:50.294Z [SparkWallet:029cabad] syncTokenOutputs: starting scope=all tokenCount=0
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit createSparkTokenClient (+0ms)
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit authenticate (+0ms)
+2026-05-11T16:54:50.294Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs starting request url=https://0.spark.lightspark.com/spark_token.SparkTokenService/query_token_outputs responseStream=false
+2026-05-11T16:54:50.294Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs wrote unary body bytes=46
+2026-05-11T16:54:50.354Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs response received status=200 headers={"date":"Mon, 11 May 2026 16:54:50 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Trace-Id, Date, Content-Type, Vary, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"910432fed94b63cf223fd5fc33e55b8e"}
+2026-05-11T16:54:50.354Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs response received status=200 responseStream=false
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs request close event
+2026-05-11T16:54:50.355Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs response has no socket to guard
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=7 chunk=1
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs response end event
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs response close event
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=21 chunk=2
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs response iterator completed after 2 chunks
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #36 /spark_token.SparkTokenService/query_token_outputs response iterator finally after 2 chunks
+2026-05-11T16:54:50.355Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.355Z [ConnectionManager:029cabad] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> completed (+60.61970800161362ms)
+2026-05-11T16:54:50.355Z [TokenTransactionService:029cabad] exit fetchOwnedTokenOutputs (+61ms)
+2026-05-11T16:54:50.355Z [SparkWallet:029cabad] syncTokenOutputs: completed outputCount=0 tokenCount=0
+2026-05-11T16:54:50.355Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.355Z [ConnectionManager:029cabad] gRPC /spark.SparkService/subscribe_to_events [path https://0.spark.lightspark.com/] session=019e17f6-74f0-7765-b708-4080c6aeb27e -> start
+2026-05-11T16:54:50.355Z [ConnectionManager:029cabad] exit prepareMetadata (+0ms)
+2026-05-11T16:54:50.355Z [ConnectionManager:029cabad] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:50.355Z [ConnectionManager:029cabad] exit authenticate (+0ms)
+2026-05-11T16:54:50.355Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events starting request url=https://0.spark.lightspark.com/spark.SparkService/subscribe_to_events responseStream=true
+2026-05-11T16:54:50.355Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events wrote unary body bytes=40
+2026-05-11T16:54:50.398Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response received status=200 headers={"date":"Mon, 11 May 2026 16:54:50 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Vary, Content-Type, grpc-status, grpc-message","vary":"Origin"}
+2026-05-11T16:54:50.398Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response received status=200 responseStream=true
+2026-05-11T16:54:50.398Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response socket unref applied
+2026-05-11T16:54:50.398Z [ConnectionManager:029cabad] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:50.398Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=1
+2026-05-11T16:54:50.398Z [SparkWallet:029cabad] setupBackgroundStream: stream event received type=connected
+2026-05-11T16:54:50.398Z [SparkWallet:029cabad] setupBackgroundStream: connected
+2026-05-11T16:54:55.398Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=2
+2026-05-11T16:55:00.399Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=3
+2026-05-11T16:55:05.399Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=4
+2026-05-11T16:55:10.400Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=5
+2026-05-11T16:55:15.401Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=6
+2026-05-11T16:55:20.400Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=7
+2026-05-11T16:55:25.400Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=8
+2026-05-11T16:55:30.400Z [BareHttpTransport:029cabad] bareHttpTransport: #37 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=9
+real 45.01
+user 0.10
+sys 0.02
+exit_code=124

--- a/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance-direct.log
+++ b/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance-direct.log
@@ -1,0 +1,709 @@
+$ timeout 45 env WATCHDOG_MS=20000 NETWORK=MAINNET yarn workspace @buildonspark/spark-bare-app repro:agent-suspend-balance
+[2026-05-11T16:54:39.279Z] starting Bare agent suspend balance repro {
+  cleanupConnections: true,
+  enableSdkLogs: true,
+  network: 'MAINNET',
+  reproMode: 'direct-suspended',
+  sdkLogLevel: 'TRACE',
+  watchdogMs: 20000
+}
+2026-05-11T16:54:39.321Z [SparkWallet:029cdf6b] createClientsAndSyncWallet: initializing network=MAINNET coordinator=[path https://0.spark.lightspark.com/] signingOperators=3
+2026-05-11T16:54:39.321Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.321Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.321Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.321Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex x3 (+0ms total)
+2026-05-11T16:54:39.321Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.321Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.321Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.321Z [ConnectionManager:029cdf6b] exit createChannelWithTLS x3 (+0ms total)
+2026-05-11T16:54:39.321Z [ConnectionManager:029cdf6b] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:39.322Z [ConnectionManager:029cdf6b] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:39.322Z [ConnectionManager:029cdf6b] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:39.322Z [ConnectionManager:029cdf6b] exit createGrpcClient x3 (+1ms total)
+2026-05-11T16:54:39.322Z [ConnectionManager:029cdf6b] exit createSparkAuthnGrpcConnection x3 (+3ms total)
+2026-05-11T16:54:39.322Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge starting request url=https://0.spark.lightspark.com/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:39.323Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge starting request url=https://spark-operator.breez.technology/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:39.323Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge starting request url=https://2.spark.flashnet.xyz/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:39.325Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:39.326Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:39.326Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:39.502Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, X-Processing-Time-Ms, X-Trace-Id, Date, Content-Type, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"2b03f6884d9150600cfbe41626bb8a9e"}
+2026-05-11T16:54:39.502Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.502Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:39.502Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:39.502Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:39.502Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:39.502Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=143 chunk=1
+2026-05-11T16:54:39.503Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:39.503Z [BareHttpTransport:029cdf6b] bareHttpTransport: #2 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:39.505Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://spark-operator.breez.technology/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:39.505Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=229
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Processing-Time-Ms, Vary, Date, Content-Type, X-Trace-Id, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"87a778699d71e944374270d5dcd23f06"}
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=122 chunk=1
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 2 chunks
+2026-05-11T16:54:39.506Z [BareHttpTransport:029cdf6b] bareHttpTransport: #1 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 2 chunks
+2026-05-11T16:54:39.507Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://0.spark.lightspark.com/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:39.507Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=230
+2026-05-11T16:54:39.546Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"05be1645a8e992d3209953ab11ed76a9"}
+2026-05-11T16:54:39.546Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.546Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:39.546Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:39.546Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:39.546Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:39.546Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=191 chunk=1
+2026-05-11T16:54:39.546Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:39.546Z [BareHttpTransport:029cdf6b] bareHttpTransport: #4 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:39.546Z [ConnectionManager:029cdf6b] exit prepareMetadata x5 (+1ms total)
+2026-05-11T16:54:39.546Z [ConnectionManager:029cdf6b] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:39.546Z [ConnectionManager:029cdf6b] exit authenticate (+225ms)
+2026-05-11T16:54:39.546Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.546Z [ConnectionManager:029cdf6b] exit createChannelWithTLS (+0ms)
+2026-05-11T16:54:39.546Z [ConnectionManager:029cdf6b] exit createMiddleware (+0ms)
+2026-05-11T16:54:39.546Z [ConnectionManager:029cdf6b] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:39.546Z [ConnectionManager:029cdf6b] exit createGrpcClient (+0ms)
+2026-05-11T16:54:39.546Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal (+225ms)
+2026-05-11T16:54:39.547Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"057368c68fd8713afe189c5a2aea0da0"}
+2026-05-11T16:54:39.547Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.547Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=170 chunk=1
+2026-05-11T16:54:39.548Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:39.548Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response end observed by premature-close guard
+2026-05-11T16:54:39.548Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:39.548Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:39.548Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.548Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 2 chunks
+2026-05-11T16:54:39.548Z [BareHttpTransport:029cdf6b] bareHttpTransport: #5 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 2 chunks
+2026-05-11T16:54:39.548Z [ConnectionManager:029cdf6b] exit createSparkClient (+225ms)
+2026-05-11T16:54:39.548Z [ConnectionManager:029cdf6b] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:39.548Z [ConnectionManager:029cdf6b] exit authenticate (+227ms)
+2026-05-11T16:54:39.548Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.548Z [ConnectionManager:029cdf6b] exit createChannelWithTLS (+0ms)
+2026-05-11T16:54:39.548Z [ConnectionManager:029cdf6b] exit createMiddleware (+0ms)
+2026-05-11T16:54:39.548Z [ConnectionManager:029cdf6b] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:39.548Z [ConnectionManager:029cdf6b] exit createGrpcClient (+0ms)
+2026-05-11T16:54:39.548Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal (+227ms)
+2026-05-11T16:54:39.556Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b4f05aad55da-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Vary, X-Processing-Time-Ms, Date, Content-Type, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"0","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=141,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:39.556Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.556Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:39.556Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:39.556Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:39.556Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:39.556Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=143 chunk=1
+2026-05-11T16:54:39.557Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:39.557Z [BareHttpTransport:029cdf6b] bareHttpTransport: #3 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:39.557Z [ConnectionManager:029cdf6b] exit createSparkClient (+227ms)
+2026-05-11T16:54:39.557Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://2.spark.flashnet.xyz/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:39.557Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=229
+2026-05-11T16:54:39.672Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b4f15f1b55da-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Vary, X-Processing-Time-Ms, Date, Content-Type, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"0","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=94,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:39.672Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.672Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:39.672Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:39.672Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:39.672Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:39.672Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=191 chunk=1
+2026-05-11T16:54:39.672Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:39.672Z [BareHttpTransport:029cdf6b] bareHttpTransport: #6 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit authenticate (+351ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit createChannelWithTLS (+0ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit createMiddleware (+0ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit createGrpcClient (+0ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal (+351ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit createSparkClient (+351ms)
+2026-05-11T16:54:39.672Z [ConnectionManager:029cdf6b] exit createClients (+351ms)
+2026-05-11T16:54:39.673Z [SparkWallet:029cdf6b] setupBackgroundStream: subscribing to [path https://0.spark.lightspark.com/] retry=0
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.673Z [SparkWallet:029cdf6b] syncTokenOutputs: starting scope=all tokenCount=0
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit authenticate (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit authenticate (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit createChannelWithTLS (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit createMiddleware (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit createMiddleware (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit getDefinitionForClientType (+0ms)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit createGrpcClient x2 (+0ms total)
+2026-05-11T16:54:39.673Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal x2 (+0ms total)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit createSparkTokenClient (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit createSparkStreamClient (+1ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:39.674Z [SparkWallet:029cdf6b] setupBackgroundStream: subscribeToEvents returned async iterator
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit subscribeToEvents (+1ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit authenticate (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:39.674Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs starting request url=https://0.spark.lightspark.com/spark_token.SparkTokenService/query_token_outputs responseStream=false
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit createSparkClient (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit authenticate (+0ms)
+2026-05-11T16:54:39.674Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.675Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_pending_transfers responseStream=false
+2026-05-11T16:54:39.675Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs wrote unary body bytes=46
+2026-05-11T16:54:39.675Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers wrote unary body bytes=48
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Trace-Id, X-Processing-Time-Ms, Date, Content-Type, Vary, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"2","x-trace-id":"54aa56cc9e7555e8d0aa890f7c2b247e"}
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response received status=200 responseStream=false
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs request close event
+2026-05-11T16:54:39.717Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response has no socket to guard
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=7 chunk=1
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response end event
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response close event
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response iterator completed after 2 chunks
+2026-05-11T16:54:39.717Z [BareHttpTransport:029cdf6b] bareHttpTransport: #7 /spark_token.SparkTokenService/query_token_outputs response iterator finally after 2 chunks
+2026-05-11T16:54:39.717Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.717Z [ConnectionManager:029cdf6b] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+43.50129100680351ms)
+2026-05-11T16:54:39.717Z [TokenTransactionService:029cdf6b] exit fetchOwnedTokenOutputs (+44ms)
+2026-05-11T16:54:39.718Z [SparkWallet:029cdf6b] syncTokenOutputs: completed outputCount=0 tokenCount=0
+2026-05-11T16:54:39.718Z [LeafManager:029cdf6b] sync: Starting sync. Pre-sync: 0 leaves, available=0 owned=0 incoming=0
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal x7 (+0ms total)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit createSparkClient x7 (+0ms total)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.718Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex x7 (+6ms total)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit makeChannelKey (+0ms)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit createAuthnMiddleware (+0ms)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit createGrpcClient x3 (+0ms total)
+2026-05-11T16:54:39.719Z [ConnectionManager:029cdf6b] exit createSparkAuthnGrpcConnection x3 (+0ms total)
+2026-05-11T16:54:39.719Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge starting request url=https://0.spark.lightspark.com/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:39.719Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge starting request url=https://spark-operator.breez.technology/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:39.719Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge starting request url=https://2.spark.flashnet.xyz/spark_authn.SparkAuthnService/get_challenge responseStream=false
+2026-05-11T16:54:39.719Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:39.719Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:39.719Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge wrote unary body bytes=40
+2026-05-11T16:54:39.761Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Content-Type, X-Trace-Id, X-Processing-Time-Ms, Vary, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"770cdcdd672de79947cffea3f1349fe7"}
+2026-05-11T16:54:39.761Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.761Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:39.761Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:39.761Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:39.761Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:39.761Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=143 chunk=1
+2026-05-11T16:54:39.761Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:39.761Z [BareHttpTransport:029cdf6b] bareHttpTransport: #10 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:39.762Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://spark-operator.breez.technology/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:39.762Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=230
+2026-05-11T16:54:39.762Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"3bb66a84f8ffad223db3f45e25c4c718"}
+2026-05-11T16:54:39.762Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.762Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:39.762Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:39.762Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=122 chunk=1
+2026-05-11T16:54:39.762Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:39.763Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:39.763Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.763Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 2 chunks
+2026-05-11T16:54:39.763Z [BareHttpTransport:029cdf6b] bareHttpTransport: #9 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 2 chunks
+2026-05-11T16:54:39.763Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://0.spark.lightspark.com/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:39.763Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=230
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Content-Type, X-Trace-Id, X-Processing-Time-Ms, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"ba54fcb969def910a8b59176cc2f1301"}
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=170 chunk=1
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 2 chunks
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #12 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 2 chunks
+2026-05-11T16:54:39.803Z [ConnectionManager:029cdf6b] exit prepareMetadata x5 (+0ms total)
+2026-05-11T16:54:39.803Z [ConnectionManager:029cdf6b] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:39.803Z [ConnectionManager:029cdf6b] exit authenticate (+85ms)
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes starting request url=https://spark-operator.breez.technology/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:39.803Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Content-Type, Vary, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"0","x-trace-id":"e48d862ce9a3006d6c7457f60659e283"}
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=191 chunk=1
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #13 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:39.805Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.805Z [ConnectionManager:029cdf6b] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:39.805Z [ConnectionManager:029cdf6b] exit authenticate x5 (+434ms total)
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes starting request url=https://0.spark.lightspark.com/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_all_transfers responseStream=false
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_all_transfers responseStream=false
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_all_transfers responseStream=false
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers starting request url=https://0.spark.lightspark.com/spark.SparkService/query_pending_transfers responseStream=false
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers wrote unary body bytes=57
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers wrote unary body bytes=63
+2026-05-11T16:54:39.805Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers wrote unary body bytes=59
+2026-05-11T16:54:39.806Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers wrote unary body bytes=48
+2026-05-11T16:54:39.847Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, Vary, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"3","x-trace-id":"8ebcc7ccd1865c5fb9f037e7c41080e1"}
+2026-05-11T16:54:39.847Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:39.847Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:39.847Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:39.847Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:39.848Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:39.848Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:39.848Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:39.848Z [BareHttpTransport:029cdf6b] bareHttpTransport: #14 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:39.848Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+129.46454200148582ms)
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, X-Trace-Id, X-Processing-Time-Ms, Date, Content-Type, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"3402b321cc68f62f40de1f1fb8042e87"}
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes response chunk received bytes=16 chunk=1
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes response iterator completed after 2 chunks
+2026-05-11T16:54:39.852Z [BareHttpTransport:029cdf6b] bareHttpTransport: #15 /spark.SparkService/query_nodes response iterator finally after 2 chunks
+2026-05-11T16:54:39.852Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+134.08620800077915ms)
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"2505cc2efb71ebaf17cfb232fb8bece6"}
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response received status=200 responseStream=false
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers request close event
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response has no socket to guard
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response chunk received bytes=16 chunk=1
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response end event
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response close event
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response iterator completed after 2 chunks
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #8 /spark.SparkService/query_pending_transfers response iterator finally after 2 chunks
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+180.69245900213718ms)
+2026-05-11T16:54:39.855Z [SparkWallet:029cdf6b] claimTransfers: found pendingTransfers=0
+2026-05-11T16:54:39.855Z [SparkWallet:029cdf6b] claimTransfers: found 0 pending transfers
+2026-05-11T16:54:39.855Z [SparkWallet:029cdf6b] claimTransfers: completed claimed=0 attempted=0
+2026-05-11T16:54:39.855Z [SparkWallet:029cdf6b] claimTransfers: completed. Claimed 0 of 0 attempted
+2026-05-11T16:54:39.855Z [SparkWallet:029cdf6b] setupBackgroundStream: claimTransfers completed claimedTransfers=0
+2026-05-11T16:54:39.855Z [SparkWallet:029cdf6b] syncTokenOutputs: starting scope=all tokenCount=0
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] exit getMonotonicTime x11 (+0ms total)
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] exit createSparkTokenClient (+0ms)
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:39.855Z [ConnectionManager:029cdf6b] exit authenticate (+0ms)
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs starting request url=https://0.spark.lightspark.com/spark_token.SparkTokenService/query_token_outputs responseStream=false
+2026-05-11T16:54:39.855Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs wrote unary body bytes=46
+2026-05-11T16:54:39.858Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b4f26b7255da-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"0","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=119,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:39.858Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.858Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge request close event
+2026-05-11T16:54:39.858Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response has no socket to guard
+2026-05-11T16:54:39.858Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response end event
+2026-05-11T16:54:39.858Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response close event
+2026-05-11T16:54:39.858Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response chunk received bytes=143 chunk=1
+2026-05-11T16:54:39.859Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:39.859Z [BareHttpTransport:029cdf6b] bareHttpTransport: #11 /spark_authn.SparkAuthnService/get_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:39.859Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.859Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge starting request url=https://2.spark.flashnet.xyz/spark_authn.SparkAuthnService/verify_challenge responseStream=false
+2026-05-11T16:54:39.860Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge wrote unary body bytes=230
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Date, Content-Type, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"2c62b713f198fa406e819a0e392d00e4"}
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs response received status=200 responseStream=false
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs request close event
+2026-05-11T16:54:39.904Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs response has no socket to guard
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=7 chunk=1
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs response end event
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs response close event
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs response iterator completed after 2 chunks
+2026-05-11T16:54:39.904Z [BareHttpTransport:029cdf6b] bareHttpTransport: #20 /spark_token.SparkTokenService/query_token_outputs response iterator finally after 2 chunks
+2026-05-11T16:54:39.904Z [ConnectionManager:029cdf6b] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+49.178791001439095ms)
+2026-05-11T16:54:39.904Z [TokenTransactionService:029cdf6b] exit fetchOwnedTokenOutputs (+49ms)
+2026-05-11T16:54:39.905Z [SparkWallet:029cdf6b] syncTokenOutputs: completed outputCount=0 tokenCount=0
+2026-05-11T16:54:39.905Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/subscribe_to_events [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:39.905Z [ConnectionManager:029cdf6b] exit getMonotonicTime x3 (+0ms total)
+2026-05-11T16:54:39.905Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:39.905Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:39.905Z [ConnectionManager:029cdf6b] exit authenticate (+0ms)
+2026-05-11T16:54:39.905Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events starting request url=https://0.spark.lightspark.com/spark.SparkService/subscribe_to_events responseStream=true
+2026-05-11T16:54:39.905Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events wrote unary body bytes=40
+2026-05-11T16:54:39.948Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Content-Type, Vary, Date, grpc-status, grpc-message","vary":"Origin"}
+2026-05-11T16:54:39.949Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response received status=200 responseStream=true
+2026-05-11T16:54:39.949Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response socket unref applied
+2026-05-11T16:54:39.949Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response chunk received bytes=7 chunk=1
+2026-05-11T16:54:39.949Z [SparkWallet:029cdf6b] setupBackgroundStream: stream event received type=connected
+2026-05-11T16:54:39.949Z [SparkWallet:029cdf6b] setupBackgroundStream: connected
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b4f33f1155da-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Date, Vary, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"0","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=88,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge response received status=200 responseStream=false
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge request close event
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge response has no socket to guard
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge response end event
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge response close event
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge response chunk received bytes=191 chunk=1
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge response iterator completed after 1 chunks
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #21 /spark_authn.SparkAuthnService/verify_challenge response iterator finally after 1 chunks
+2026-05-11T16:54:39.966Z [ConnectionManager:029cdf6b] exit getMonotonicTime x2 (+0ms total)
+2026-05-11T16:54:39.966Z [ConnectionManager:029cdf6b] exit getCurrentServerTime (+0ms)
+2026-05-11T16:54:39.966Z [ConnectionManager:029cdf6b] exit authenticate (+248ms)
+2026-05-11T16:54:39.966Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes starting request url=https://2.spark.flashnet.xyz/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:39.966Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:39.987Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Trace-Id, X-Processing-Time-Ms, Vary, Date, Content-Type, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"8","x-trace-id":"1c0b7a7c291f0ec240959df6d7db0b1d"}
+2026-05-11T16:54:39.987Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response received status=200 responseStream=false
+2026-05-11T16:54:39.987Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers request close event
+2026-05-11T16:54:39.987Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.987Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response has no socket to guard
+2026-05-11T16:54:39.987Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response end event
+2026-05-11T16:54:39.987Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response close event
+2026-05-11T16:54:39.987Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response chunk received bytes=37 chunk=1
+2026-05-11T16:54:39.987Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response iterator completed after 1 chunks
+2026-05-11T16:54:39.987Z [BareHttpTransport:029cdf6b] bareHttpTransport: #17 /spark.SparkService/query_all_transfers response iterator finally after 1 chunks
+2026-05-11T16:54:39.988Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.988Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+269.0824999958277ms)
+2026-05-11T16:54:39.988Z [TransferService:029cdf6b] exit queryPendingTransfers (+181ms)
+2026-05-11T16:54:39.988Z [TransferService:029cdf6b] exit queryAllTransfers (+270ms)
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Content-Type, X-Processing-Time-Ms, X-Trace-Id, Vary, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"697fa4139b91500aa5fb8286c1c320ae"}
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response received status=200 responseStream=false
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers request close event
+2026-05-11T16:54:39.998Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response has no socket to guard
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response chunk received bytes=16 chunk=1
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response end event
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response close event
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response iterator completed after 2 chunks
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #16 /spark.SparkService/query_all_transfers response iterator finally after 2 chunks
+2026-05-11T16:54:39.998Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.998Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+279.6467909961939ms)
+2026-05-11T16:54:39.998Z [TransferService:029cdf6b] exit queryCounterSwapTransfers (+270ms)
+2026-05-11T16:54:39.998Z [TransferService:029cdf6b] exit queryAllTransfers (+280ms)
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Processing-Time-Ms, X-Trace-Id, Vary, Date, Content-Type, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"7e8de3ad583169e549df6ff434ee9bb7"}
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers response received status=200 responseStream=false
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers request close event
+2026-05-11T16:54:39.998Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers response has no socket to guard
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers response end event
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers response close event
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers response chunk received bytes=37 chunk=1
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers response iterator completed after 1 chunks
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #18 /spark.SparkService/query_all_transfers response iterator finally after 1 chunks
+2026-05-11T16:54:39.998Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.998Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_all_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+279.8614999949932ms)
+2026-05-11T16:54:39.998Z [TransferService:029cdf6b] exit queryPrimarySwapTransfers (+280ms)
+2026-05-11T16:54:39.998Z [TransferService:029cdf6b] exit queryAllTransfers (+280ms)
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers response received status=200 headers={"date":"Mon, 11 May 2026 16:54:39 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Content-Type, X-Trace-Id, X-Processing-Time-Ms, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"6bc0444dfaa311b77a1837ab2b30fb75"}
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers response received status=200 responseStream=false
+2026-05-11T16:54:39.998Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.998Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers response chunk received bytes=16 chunk=1
+2026-05-11T16:54:39.999Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers response end event
+2026-05-11T16:54:39.999Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers response end observed by premature-close guard
+2026-05-11T16:54:39.999Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers response close event
+2026-05-11T16:54:39.999Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers request close event
+2026-05-11T16:54:39.999Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers response chunk received bytes=21 chunk=2
+2026-05-11T16:54:39.999Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers response iterator completed after 2 chunks
+2026-05-11T16:54:39.999Z [BareHttpTransport:029cdf6b] bareHttpTransport: #19 /spark.SparkService/query_pending_transfers response iterator finally after 2 chunks
+2026-05-11T16:54:39.999Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:39.999Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_pending_transfers [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+280.4870420098305ms)
+2026-05-11T16:54:39.999Z [TransferService:029cdf6b] exit queryPendingOutgoingTransfers (+280ms)
+2026-05-11T16:54:39.999Z [TransferService:029cdf6b] exit queryPendingTransfers (+281ms)
+2026-05-11T16:54:40.084Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:40 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b4f3e9c055da-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Vary, Date, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"1","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=96,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:40.084Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:40.084Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:40.084Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.084Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:40.084Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:40.084Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:40.084Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:40.084Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:40.084Z [BareHttpTransport:029cdf6b] bareHttpTransport: #23 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:40.084Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.084Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+365.8472080081701ms)
+2026-05-11T16:54:40.084Z [LeafManager:029cdf6b] sync: Fetched: 0 leaves, 0 pending swaps, 0 outgoing, 0 incoming
+2026-05-11T16:54:40.085Z [LeafManager:029cdf6b] sync: Complete. Post-sync: leaves=0 available=0 owned=0 incoming=0 statusCounts=AVAILABLE=0 LOCAL_LOCKED=0 OUTGOING=0 SWAP_PENDING=0 INCOMING=0 SPENT=0
+2026-05-11T16:54:40.085Z [LeafManager:029cdf6b] autoOptimizeIfNeeded: No optimization needed for 0 leaves
+2026-05-11T16:54:40.085Z [SparkWallet:029cdf6b] createClientsAndSyncWallet: initial wallet sync complete
+2026-05-11T16:54:40.086Z [SparkWallet:029cdf6b] exit initialize (+804ms)
+[2026-05-11T16:54:40.086Z] wallet initialized
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal x3 (+0ms total)
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit createSparkClient x3 (+0ms total)
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.086Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.087Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.087Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex x3 (+2ms total)
+2026-05-11T16:54:40.087Z [ConnectionManager:029cdf6b] exit authenticate x3 (+2ms total)
+2026-05-11T16:54:40.087Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.087Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes starting request url=https://0.spark.lightspark.com/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:40.087Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.087Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes starting request url=https://spark-operator.breez.technology/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:40.087Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.087Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes starting request url=https://2.spark.flashnet.xyz/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:40.087Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:40.087Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:40.087Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:40.133Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:40 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Content-Type, X-Processing-Time-Ms, X-Trace-Id, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"3","x-trace-id":"4c249534c580d587152f3bc629dc8d86"}
+2026-05-11T16:54:40.133Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:40.133Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:40.133Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.133Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:40.133Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:40.133Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:40.133Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:40.133Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:40.133Z [BareHttpTransport:029cdf6b] bareHttpTransport: #25 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:40.133Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.133Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+46.90350000560284ms)
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:40 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Content-Type, X-Processing-Time-Ms, X-Trace-Id, Vary, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"7","x-trace-id":"51c1a2311944002b8e5d106aba45f4db"}
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:40.137Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes response chunk received bytes=16 chunk=1
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes response chunk received bytes=21 chunk=2
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes response iterator completed after 2 chunks
+2026-05-11T16:54:40.137Z [BareHttpTransport:029cdf6b] bareHttpTransport: #24 /spark.SparkService/query_nodes response iterator finally after 2 chunks
+2026-05-11T16:54:40.137Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.137Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+50.376749992370605ms)
+2026-05-11T16:54:40.211Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:40 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b4f4ad0055da-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"X-Processing-Time-Ms, Date, Content-Type, Vary, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"1","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=98,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:40.211Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:40.211Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:40.211Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.211Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:40.211Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:40.211Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:40.211Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:40.212Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:40.212Z [BareHttpTransport:029cdf6b] bareHttpTransport: #26 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+125.17433300614357ms)
+2026-05-11T16:54:40.212Z [SparkWallet:029cdf6b] syncTokenOutputs: starting scope=all tokenCount=0
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] exit createSparkTokenClient (+0ms)
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] exit authenticate (+0ms)
+2026-05-11T16:54:40.212Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.212Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs starting request url=https://0.spark.lightspark.com/spark_token.SparkTokenService/query_token_outputs responseStream=false
+2026-05-11T16:54:40.212Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs wrote unary body bytes=46
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response received status=200 headers={"date":"Mon, 11 May 2026 16:54:40 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Date, Content-Type, Vary, X-Trace-Id, X-Processing-Time-Ms, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"5ddf771201263ac8e90c47ff78bd725d"}
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response received status=200 responseStream=false
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs request close event
+2026-05-11T16:54:40.264Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response has no socket to guard
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=7 chunk=1
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response end event
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response close event
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=21 chunk=2
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response iterator completed after 2 chunks
+2026-05-11T16:54:40.264Z [BareHttpTransport:029cdf6b] bareHttpTransport: #27 /spark_token.SparkTokenService/query_token_outputs response iterator finally after 2 chunks
+2026-05-11T16:54:40.264Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.264Z [ConnectionManager:029cdf6b] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+51.945999994874ms)
+2026-05-11T16:54:40.264Z [TokenTransactionService:029cdf6b] exit fetchOwnedTokenOutputs (+52ms)
+2026-05-11T16:54:40.264Z [SparkWallet:029cdf6b] syncTokenOutputs: completed outputCount=0 tokenCount=0
+2026-05-11T16:54:40.264Z [SparkWallet:029cdf6b] exit getBalance (+178ms)
+[2026-05-11T16:54:40.265Z] initial balance resolved after 179ms {
+  balance: 0n,
+  satsBalance: { available: 0n, owned: 0n, incoming: 0n },
+  tokenBalances: Map(0) {}
+}
+[2026-05-11T16:54:40.266Z] agents suspended
+[2026-05-11T16:54:40.266Z] calling wallet.getBalance() directly while agents are suspended
+2026-05-11T16:54:40.266Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events socket close observed by premature-close guard
+2026-05-11T16:54:40.266Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events forcing response teardown after socket close
+2026-05-11T16:54:40.266Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.266Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.266Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events request close event
+2026-05-11T16:54:40.266Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response error event: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:40.266Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response close event
+2026-05-11T16:54:40.266Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.266Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response iterator error after 1 chunks: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:40.269Z [BareHttpTransport:029cdf6b] bareHttpTransport: #22 /spark.SparkService/subscribe_to_events response iterator finally after 1 chunks
+2026-05-11T16:54:40.269Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal x3 (+0ms total)
+2026-05-11T16:54:40.269Z [ConnectionManager:029cdf6b] exit createSparkClient x3 (+9ms total)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex x3 (+0ms total)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/subscribe_to_events [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> error (+365.15987499058247ms): /spark.SparkService/subscribe_to_events UNKNOWN: Transport error: /spark.SparkService/subscribe_to_events UNAVAILABLE: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit authenticate x3 (+0ms total)
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] error handleMiddlewareError (+0ms): /spark.SparkService/subscribe_to_events UNKNOWN: Transport error: /spark.SparkService/subscribe_to_events UNAVAILABLE: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.270Z [BareHttpTransport:029cdf6b] bareHttpTransport: #28 /spark.SparkService/query_nodes starting request url=https://0.spark.lightspark.com/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.270Z [BareHttpTransport:029cdf6b] bareHttpTransport: #29 /spark.SparkService/query_nodes starting request url=https://spark-operator.breez.technology/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:40.270Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.270Z [BareHttpTransport:029cdf6b] bareHttpTransport: #30 /spark.SparkService/query_nodes starting request url=https://2.spark.flashnet.xyz/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:40.270Z [SparkWallet:029cdf6b] setupBackgroundStream: stream iterator threw: /spark.SparkService/subscribe_to_events UNKNOWN: Transport error: /spark.SparkService/subscribe_to_events UNAVAILABLE: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events
+2026-05-11T16:54:40.270Z [SparkWallet:029cdf6b] setupBackgroundStream: error: /spark.SparkService/subscribe_to_events UNKNOWN: Transport error: /spark.SparkService/subscribe_to_events UNAVAILABLE: UNAVAILABLE: response stream closed before completion (socket close) for /spark.SparkService/subscribe_to_events; retrying in 1000ms (attempt=1)
+2026-05-11T16:54:40.270Z [BareHttpTransport:029cdf6b] bareHttpTransport: #28 /spark.SparkService/query_nodes request setup failed: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:40.270Z [BareHttpTransport:029cdf6b] bareHttpTransport: #29 /spark.SparkService/query_nodes request setup failed: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:40.270Z [BareHttpTransport:029cdf6b] bareHttpTransport: #30 /spark.SparkService/query_nodes request setup failed: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> error (+1.0719169974327087ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> error (+1.0593329966068268ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> error (+1.0496660023927689ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] error handleMiddlewareError (+0ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] error handleMiddlewareError (+0ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] error handleMiddlewareError (+0ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended
+2026-05-11T16:54:40.271Z [SparkWallet:029cdf6b] error getBalance (+5ms): /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended [serverTraceId: 5ddf771201263ac8e90c47ff78bd725d, idPubKey: 029cdf6bfdeee4fff6ad63f21048675c6deb072086f5876633399d201fb6d51398, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-11T16:54:40.271Z] direct suspended balance rejected SparkError: /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended [serverTraceId: 5ddf771201263ac8e90c47ff78bd725d, idPubKey: 029cdf6bfdeee4fff6ad63f21048675c6deb072086f5876633399d201fb6d51398, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-11T16:54:40.271Z] agents resumed
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal x3 (+0ms total)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit createSparkClient x3 (+0ms total)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex x3 (+0ms total)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit authenticate x3 (+0ms total)
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.271Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes starting request url=https://0.spark.lightspark.com/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.271Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes starting request url=https://spark-operator.breez.technology/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:40.271Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.271Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes starting request url=https://2.spark.flashnet.xyz/spark.SparkService/query_nodes responseStream=false
+2026-05-11T16:54:40.272Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:40.272Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:40.272Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes wrote unary body bytes=47
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:40 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"X-Processing-Time-Ms, Vary, Date, Content-Type, X-Trace-Id, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"3","x-trace-id":"fb8e731cf241691477a5d28bb5922b90"}
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:40.456Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #31 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:40.456Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.456Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+184.60729199647903ms)
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:40 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","cf-ray":"9fa2b4f62892c213-LAX","cf-cache-status":"DYNAMIC","access-control-allow-origin":"*","server":"cloudflare","vary":"Origin","access-control-allow-headers":"*","access-control-allow-methods":"POST, GET, OPTIONS","access-control-max-age":"86400","access-control-expose-headers":"Date, Vary, Content-Type, X-Processing-Time-Ms, grpc-status, grpc-message","expect-ct":"max-age=86400, enforce","referrer-policy":"same-origin","x-content-type-options":"nosniff","x-frame-options":"SAMEORIGIN","x-processing-time-ms":"1","x-xss-protection":"1; mode=block","server-timing":"cfCacheStatus;desc=\"DYNAMIC\", cfEdge;dur=113,cfOrigin;dur=0","alt-svc":"h3=\":443\"; ma=86400"}
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:40.456Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:40.456Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:40.457Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:40.457Z [BareHttpTransport:029cdf6b] bareHttpTransport: #33 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:40.457Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.457Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://2.spark.flashnet.xyz/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+185.2417080104351ms)
+2026-05-11T16:54:40.459Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes response received status=200 headers={"date":"Mon, 11 May 2026 16:54:40 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, Content-Type, X-Trace-Id, X-Processing-Time-Ms, Date, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"c39c95b78847318350610bbe62b839e9"}
+2026-05-11T16:54:40.459Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes response received status=200 responseStream=false
+2026-05-11T16:54:40.459Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes request close event
+2026-05-11T16:54:40.459Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.459Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes response has no socket to guard
+2026-05-11T16:54:40.459Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes response end event
+2026-05-11T16:54:40.460Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes response close event
+2026-05-11T16:54:40.460Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes response chunk received bytes=37 chunk=1
+2026-05-11T16:54:40.460Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes response iterator completed after 1 chunks
+2026-05-11T16:54:40.460Z [BareHttpTransport:029cdf6b] bareHttpTransport: #32 /spark.SparkService/query_nodes response iterator finally after 1 chunks
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] gRPC /spark.SparkService/query_nodes [path https://spark-operator.breez.technology/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+188.28191600739956ms)
+2026-05-11T16:54:40.460Z [SparkWallet:029cdf6b] syncTokenOutputs: starting scope=all tokenCount=0
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] exit getAddressToClientMap (+0ms)
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] exit getOrCreateClientInternal (+0ms)
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] exit createSparkTokenClient (+0ms)
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> start
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] exit prepareMetadata (+0ms)
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] exit getIdentityPublicKeyHex (+0ms)
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] exit authenticate (+0ms)
+2026-05-11T16:54:40.460Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.460Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs starting request url=https://0.spark.lightspark.com/spark_token.SparkTokenService/query_token_outputs responseStream=false
+2026-05-11T16:54:40.460Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs wrote unary body bytes=46
+2026-05-11T16:54:40.509Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response received status=200 headers={"date":"Mon, 11 May 2026 16:54:40 GMT","content-type":"application/grpc-web+proto","transfer-encoding":"chunked","connection":"keep-alive","access-control-expose-headers":"Vary, X-Processing-Time-Ms, Date, Content-Type, X-Trace-Id, grpc-status, grpc-message","vary":"Origin","x-processing-time-ms":"6","x-trace-id":"a5469b94a2393c057dbad296fb4f00a6"}
+2026-05-11T16:54:40.509Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response received status=200 responseStream=false
+2026-05-11T16:54:40.510Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs request close event
+2026-05-11T16:54:40.510Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.510Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response has no socket to guard
+2026-05-11T16:54:40.510Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response end event
+2026-05-11T16:54:40.510Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response close event
+2026-05-11T16:54:40.510Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response chunk received bytes=28 chunk=1
+2026-05-11T16:54:40.510Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response iterator completed after 1 chunks
+2026-05-11T16:54:40.510Z [BareHttpTransport:029cdf6b] bareHttpTransport: #34 /spark_token.SparkTokenService/query_token_outputs response iterator finally after 1 chunks
+2026-05-11T16:54:40.510Z [ConnectionManager:029cdf6b] exit getMonotonicTime (+0ms)
+2026-05-11T16:54:40.510Z [ConnectionManager:029cdf6b] gRPC /spark_token.SparkTokenService/query_token_outputs [path https://0.spark.lightspark.com/] session=019e17f6-51b1-76af-8e22-2dadb862b077 -> completed (+49.917166993021965ms)
+2026-05-11T16:54:40.510Z [TokenTransactionService:029cdf6b] exit fetchOwnedTokenOutputs (+50ms)
+2026-05-11T16:54:40.510Z [SparkWallet:029cdf6b] syncTokenOutputs: completed outputCount=0 tokenCount=0
+2026-05-11T16:54:40.510Z [SparkWallet:029cdf6b] exit getBalance (+239ms)
+[2026-05-11T16:54:40.510Z] fresh balance after direct suspended call resolved after 239ms {
+  balance: 0n,
+  satsBalance: { available: 0n, owned: 0n, incoming: 0n },
+  tokenBalances: Map(0) {}
+}
+[2026-05-11T16:54:40.510Z] cleaning up wallet connections
+2026-05-11T16:54:40.511Z [SparkWallet:029cdf6b] setupBackgroundStream: stream loop iteration finished retryCount=1 aborted=true
+2026-05-11T16:54:40.511Z [ConnectionManager:029cdf6b] exit closeConnections (+1ms)
+2026-05-11T16:54:40.511Z [SparkWallet:029cdf6b] exit cleanupConnections (+1ms)
+[2026-05-11T16:54:40.511Z] repro script completed
+real 2.46
+user 1.15
+sys 0.17
+exit_code=0

--- a/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance-no-cleanup.log
+++ b/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance-no-cleanup.log
@@ -1,0 +1,26 @@
+$ timeout 45 env WATCHDOG_MS=20000 CLEANUP_CONNECTIONS=0 NETWORK=MAINNET bare repro-agent-suspend-balance.js
+[2026-05-08T19:22:12.690Z] starting Bare agent suspend balance repro { cleanupConnections: false, network: 'MAINNET', watchdogMs: 20000 }
+[2026-05-08T19:22:13.325Z] wallet initialized
+[2026-05-08T19:22:13.451Z] initial balance resolved after 126ms {
+  balance: 0n,
+  satsBalance: { available: 0n, owned: 0n, incoming: 0n },
+  tokenBalances: Map(0) {}
+}
+[2026-05-08T19:22:13.454Z] agents suspended
+[2026-05-08T19:22:13.463Z] balance while agents already suspended rejected after 9ms SparkError: /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended [serverTraceId: 2dfbebb254e9ab81ca080fd9a1813ee5, idPubKey: 0350828c5f1c7377fe8828473bc2a3c30ebac45ebb1946e9d13c889848c43eb898, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-08T19:22:13.464Z] agents resumed
+[2026-05-08T19:22:13.464Z] same already-suspended balance promise after resume rejected after 0ms SparkError: /spark.SparkService/query_nodes UNKNOWN: Transport error: AGENT_SUSPENDED: Agent is suspended [serverTraceId: 2dfbebb254e9ab81ca080fd9a1813ee5, idPubKey: 0350828c5f1c7377fe8828473bc2a3c30ebac45ebb1946e9d13c889848c43eb898, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-08T19:22:13.466Z] agents suspended
+[2026-05-08T19:22:28.470Z] balance suspended while in flight rejected after 15004ms SparkError: /spark.SparkService/query_nodes UNKNOWN: Transport error: /spark.SparkService/query_nodes UNAVAILABLE: UNAVAILABLE: request timed out after 15000ms [serverTraceId: 2dfbebb254e9ab81ca080fd9a1813ee5, idPubKey: 0350828c5f1c7377fe8828473bc2a3c30ebac45ebb1946e9d13c889848c43eb898, clientEnv: js-spark-sdk/0.7.17 bare/v1.28.4]
+[2026-05-08T19:22:28.470Z] agents resumed
+[2026-05-08T19:22:28.704Z] fresh balance after resume resolved after 234ms {
+  balance: 0n,
+  satsBalance: { available: 0n, owned: 0n, incoming: 0n },
+  tokenBalances: Map(0) {}
+}
+[2026-05-08T19:22:28.704Z] skipping wallet cleanup; process should exit only if no SDK handles keep it alive
+[2026-05-08T19:22:28.704Z] repro script completed
+real 45.01
+user 0.46
+sys 0.10
+exit_code=124

--- a/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance.js
+++ b/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance.js
@@ -6,6 +6,9 @@ import walletConfig, { getExampleWalletOptions } from "./wallet-config.js";
 
 const WATCHDOG_MS = Number(process.env.WATCHDOG_MS ?? 30_000);
 const CLEANUP_CONNECTIONS = process.env.CLEANUP_CONNECTIONS !== "0";
+const ENABLE_SDK_LOGS = process.env.ENABLE_SDK_LOGS !== "0";
+const SDK_LOG_LEVEL = process.env.SDK_LOG_LEVEL ?? "TRACE";
+const REPRO_MODE = process.env.REPRO_MODE ?? "direct-suspended";
 
 function log(message, details) {
   const prefix = `[${new Date().toISOString()}]`;
@@ -70,22 +73,26 @@ async function nextTick() {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-async function main() {
-  log("starting Bare agent suspend balance repro", {
-    cleanupConnections: CLEANUP_CONNECTIONS,
-    network: process.env.NETWORK ?? process.env.SPARK_NETWORK ?? "MAINNET",
-    watchdogMs: WATCHDOG_MS,
-  });
+async function runDirectSuspendedBalance(wallet) {
+  suspendAgents();
+  log("calling wallet.getBalance() directly while agents are suspended");
 
-  const options = getExampleWalletOptions(process.env, "MAINNET");
-  const { wallet } = await SparkWallet.initialize({
-    mnemonicOrSeed: process.env.MNEMONIC ?? walletConfig.mnemonic,
-    options,
-  });
+  try {
+    const balance = await wallet.getBalance();
+    log("direct suspended balance resolved", balance);
+  } catch (error) {
+    log("direct suspended balance rejected", formatError(error));
+  } finally {
+    resumeAgents();
+  }
 
-  log("wallet initialized");
-  await raceWithWatchdog("initial balance", wallet.getBalance());
+  await raceWithWatchdog(
+    "fresh balance after direct suspended call",
+    wallet.getBalance(),
+  );
+}
 
+async function runWatchdogComparison(wallet) {
   suspendAgents();
   const alreadySuspendedBalance = wallet.getBalance();
   await raceWithWatchdog(
@@ -105,6 +112,39 @@ async function main() {
   resumeAgents();
 
   await raceWithWatchdog("fresh balance after resume", wallet.getBalance());
+}
+
+async function main() {
+  log("starting Bare agent suspend balance repro", {
+    cleanupConnections: CLEANUP_CONNECTIONS,
+    enableSdkLogs: ENABLE_SDK_LOGS,
+    network: process.env.NETWORK ?? process.env.SPARK_NETWORK ?? "MAINNET",
+    reproMode: REPRO_MODE,
+    sdkLogLevel: ENABLE_SDK_LOGS ? SDK_LOG_LEVEL : "off",
+    watchdogMs: WATCHDOG_MS,
+  });
+
+  const options = {
+    ...getExampleWalletOptions(process.env, "MAINNET"),
+    ...(ENABLE_SDK_LOGS ? { log: SDK_LOG_LEVEL } : {}),
+  };
+  const { wallet } = await SparkWallet.initialize({
+    mnemonicOrSeed: process.env.MNEMONIC ?? walletConfig.mnemonic,
+    options,
+  });
+
+  log("wallet initialized");
+  await raceWithWatchdog("initial balance", wallet.getBalance());
+
+  if (REPRO_MODE === "race") {
+    await runWatchdogComparison(wallet);
+  } else if (REPRO_MODE === "direct-suspended") {
+    await runDirectSuspendedBalance(wallet);
+  } else {
+    throw new Error(
+      `Unknown REPRO_MODE ${REPRO_MODE}; expected direct-suspended or race`,
+    );
+  }
 
   if (CLEANUP_CONNECTIONS) {
     log("cleaning up wallet connections");

--- a/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance.js
+++ b/sdks/js/examples/spark-bare-app/repro-agent-suspend-balance.js
@@ -1,0 +1,124 @@
+import { SparkWallet } from "@buildonspark/bare";
+import { globalAgent as http1Agent } from "bare-http1";
+import { globalAgent as httpsAgent } from "bare-https";
+import process from "bare-process";
+import walletConfig, { getExampleWalletOptions } from "./wallet-config.js";
+
+const WATCHDOG_MS = Number(process.env.WATCHDOG_MS ?? 30_000);
+const CLEANUP_CONNECTIONS = process.env.CLEANUP_CONNECTIONS !== "0";
+
+function log(message, details) {
+  const prefix = `[${new Date().toISOString()}]`;
+  if (details === undefined) {
+    console.log(`${prefix} ${message}`);
+    return;
+  }
+  console.log(`${prefix} ${message}`, details);
+}
+
+function formatError(error) {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+async function raceWithWatchdog(label, promise) {
+  const start = Date.now();
+  let watchdogTimer;
+  const watchdog = new Promise((resolve) => {
+    watchdogTimer = setTimeout(
+      () => resolve({ type: "watchdog" }),
+      WATCHDOG_MS,
+    );
+  });
+  const result = await Promise.race([
+    promise.then(
+      (value) => ({ type: "resolved", value }),
+      (error) => ({ type: "rejected", error }),
+    ),
+    watchdog,
+  ]).finally(() => {
+    clearTimeout(watchdogTimer);
+  });
+  const elapsedMs = Date.now() - start;
+
+  if (result.type === "resolved") {
+    log(`${label} resolved after ${elapsedMs}ms`, result.value);
+  } else if (result.type === "rejected") {
+    log(`${label} rejected after ${elapsedMs}ms`, formatError(result.error));
+  } else {
+    log(`${label} still pending after ${elapsedMs}ms`);
+  }
+
+  return result;
+}
+
+function suspendAgents() {
+  http1Agent.suspend();
+  httpsAgent.suspend();
+  log("agents suspended");
+}
+
+function resumeAgents() {
+  http1Agent.resume();
+  httpsAgent.resume();
+  log("agents resumed");
+}
+
+async function nextTick() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function main() {
+  log("starting Bare agent suspend balance repro", {
+    cleanupConnections: CLEANUP_CONNECTIONS,
+    network: process.env.NETWORK ?? process.env.SPARK_NETWORK ?? "MAINNET",
+    watchdogMs: WATCHDOG_MS,
+  });
+
+  const options = getExampleWalletOptions(process.env, "MAINNET");
+  const { wallet } = await SparkWallet.initialize({
+    mnemonicOrSeed: process.env.MNEMONIC ?? walletConfig.mnemonic,
+    options,
+  });
+
+  log("wallet initialized");
+  await raceWithWatchdog("initial balance", wallet.getBalance());
+
+  suspendAgents();
+  const alreadySuspendedBalance = wallet.getBalance();
+  await raceWithWatchdog(
+    "balance while agents already suspended",
+    alreadySuspendedBalance,
+  );
+  resumeAgents();
+  await raceWithWatchdog(
+    "same already-suspended balance promise after resume",
+    alreadySuspendedBalance,
+  );
+
+  const inFlightBalance = wallet.getBalance();
+  await nextTick();
+  suspendAgents();
+  await raceWithWatchdog("balance suspended while in flight", inFlightBalance);
+  resumeAgents();
+
+  await raceWithWatchdog("fresh balance after resume", wallet.getBalance());
+
+  if (CLEANUP_CONNECTIONS) {
+    log("cleaning up wallet connections");
+    await wallet.cleanupConnections();
+  } else {
+    log(
+      "skipping wallet cleanup; process should exit only if no SDK handles keep it alive",
+    );
+  }
+
+  log("repro script completed");
+}
+
+main().catch((error) => {
+  log("repro script failed", formatError(error));
+  process.exit(1);
+});

--- a/sdks/js/examples/spark-bare-app/scripts/run-script.mjs
+++ b/sdks/js/examples/spark-bare-app/scripts/run-script.mjs
@@ -7,6 +7,7 @@ const VALID_SCRIPTS = new Set([
   "create-lightning-invoice",
   "get-static-deposit-address",
   "get-or-create-wallet",
+  "repro-agent-suspend-balance",
   "transfer",
 ]);
 

--- a/sdks/js/examples/spark-bare-app/transfer.js
+++ b/sdks/js/examples/spark-bare-app/transfer.js
@@ -5,15 +5,20 @@ import walletConfig, { getExampleWalletOptions } from "./wallet-config.js";
 
 async function transfer(mnemonicInit, receiverSparkAddress, amountSats) {
   const options = getExampleWalletOptions(process.env, "REGTEST");
-  let { wallet } = await SparkWallet.initialize({
-    mnemonicOrSeed: mnemonicInit,
-    options,
-  });
-  const transfer = await wallet.transfer({
-    receiverSparkAddress,
-    amountSats: Number(amountSats),
-  });
-  return transfer;
+  let wallet;
+  try {
+    const initialized = await SparkWallet.initialize({
+      mnemonicOrSeed: mnemonicInit,
+      options,
+    });
+    wallet = initialized.wallet;
+    return await wallet.transfer({
+      receiverSparkAddress,
+      amountSats: Number(amountSats),
+    });
+  } finally {
+    await wallet?.cleanupConnections();
+  }
 }
 
 const args = process.argv.slice(2);
@@ -50,7 +55,6 @@ try {
     amountSats,
   );
   console.log("Transfer result:", transferResult);
-  process.exit(0);
 } catch (error) {
   console.error(error);
   process.exit(1);

--- a/sdks/js/yarn.lock
+++ b/sdks/js/yarn.lock
@@ -220,6 +220,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:8.0.0-rc.2":
+  version: 8.0.0-rc.2
+  resolution: "@babel/generator@npm:8.0.0-rc.2"
+  dependencies:
+    "@babel/parser": "npm:^8.0.0-rc.2"
+    "@babel/types": "npm:^8.0.0-rc.2"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    "@types/jsesc": "npm:^2.5.0"
+    jsesc: "npm:^3.0.2"
+  checksum: 10/32793849fdd473e256cb88d194b91390880d0fdb4bffe07450c19483c8565613bcb79105f1508bceb5723bcd4ecbcf500044532ab2cb4a722f993b2a76e6dca9
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.20.5, @babel/generator@npm:^7.25.0, @babel/generator@npm:^7.28.5, @babel/generator@npm:^7.7.2":
   version: 7.28.5
   resolution: "@babel/generator@npm:7.28.5"
@@ -230,19 +244,6 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
   checksum: 10/ae618f0a17a6d76c3983e1fd5d9c2f5fdc07703a119efdb813a7d9b8ad4be0a07d4c6f0d718440d2de01a68e321f64e2d63c77fc5d43ae47ae143746ef28ac1f
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/generator@npm:7.28.6"
-  dependencies:
-    "@babel/parser": "npm:^7.28.6"
-    "@babel/types": "npm:^7.28.6"
-    "@jridgewell/gen-mapping": "npm:^0.3.12"
-    "@jridgewell/trace-mapping": "npm:^0.3.28"
-    jsesc: "npm:^3.0.2"
-  checksum: 10/ef2af927e8e0985d02ec4321a242da761a934e927539147c59fdd544034dc7f0e9846f6bf86209aca7a28aee2243ed0fad668adccd48f96d7d6866215173f9af
   languageName: node
   linkType: hard
 
@@ -412,10 +413,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^8.0.0-rc.2, @babel/helper-string-parser@npm:^8.0.0-rc.4":
+  version: 8.0.0-rc.4
+  resolution: "@babel/helper-string-parser@npm:8.0.0-rc.4"
+  checksum: 10/9d906b864a31580ee6806432d0634a3f21e20d5269997f752e3682e0ef3402f54d5246b5b36d06a0bdd2cd6fe4fb49a8b6761581b95b2c20707392b04754d131
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:8.0.0-rc.2":
+  version: 8.0.0-rc.2
+  resolution: "@babel/helper-validator-identifier@npm:8.0.0-rc.2"
+  checksum: 10/91c38b24ef9222a7730caeb1a7dad10808fe95c49ac2a8efbd313c6aee2e1a130fa906fbce6cefb76bc88d950386aacb230c3ff9cbbbe8ea2d304ef9756b8a86
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.25.9, @babel/helper-validator-identifier@npm:^7.27.1, @babel/helper-validator-identifier@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
   checksum: 10/8e5d9b0133702cfacc7f368bf792f0f8ac0483794877c6dca5fcb73810ee138e27527701826fb58a40a004f3a5ec0a2f3c3dd5e326d262530b119918f3132ba7
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^8.0.0-rc.2, @babel/helper-validator-identifier@npm:^8.0.0-rc.4":
+  version: 8.0.0-rc.4
+  resolution: "@babel/helper-validator-identifier@npm:8.0.0-rc.4"
+  checksum: 10/ca92b391cd8e0e3be3d006098e01b4d8a88a4cd6364a3c2993b37838df72c0d7fda14b547e16b6baef3701078ff569d1b0eaec27f7df7b791770fc51e5ca237f
   languageName: node
   linkType: hard
 
@@ -459,6 +481,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:8.0.0-rc.2":
+  version: 8.0.0-rc.2
+  resolution: "@babel/parser@npm:8.0.0-rc.2"
+  dependencies:
+    "@babel/types": "npm:^8.0.0-rc.2"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/a0488f9f5dc2a596e8d7b23a444f109ad83ccd38308bb58ee7ad2710140edf23e5ae25dda696922ae5fcb33203c7ca0e7541bbad9e7acb6fa04ffec48c807573
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.26.7, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/parser@npm:7.28.5"
@@ -470,14 +503,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/parser@npm:7.28.6"
+"@babel/parser@npm:^8.0.0-beta.4, @babel/parser@npm:^8.0.0-rc.2":
+  version: 8.0.0-rc.4
+  resolution: "@babel/parser@npm:8.0.0-rc.4"
   dependencies:
-    "@babel/types": "npm:^7.28.6"
+    "@babel/types": "npm:^8.0.0-rc.4"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10/483a6fb5f9876ec9cbbb98816f2c94f39ae4d1158d35f87e1c4bf19a1f56027c96a1a3962ff0c8c46e8322a6d9e1c80d26b7f9668410df13d5b5769d9447b010
+  checksum: 10/f3a962025cbde82650af74e54e0d97363fe1c478bd7e7077894ef24d67b779fa8b72f0017bfd3b082f017f2affab6a8c86d7f35d98081f68a30f1f2c1d1dfd75
   languageName: node
   linkType: hard
 
@@ -1699,6 +1732,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:8.0.0-rc.2":
+  version: 8.0.0-rc.2
+  resolution: "@babel/types@npm:8.0.0-rc.2"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^8.0.0-rc.2"
+    "@babel/helper-validator-identifier": "npm:^8.0.0-rc.2"
+  checksum: 10/825368169a4f72a94e555dd31e61cb91619f140cf8a07894ae598a823d9e07a1e455ad57c828f0d09b04f71f59faaf1905ff054a01d83146cf2b62950b34261c
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.2, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4, @babel/types@npm:^7.28.5, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.28.5
   resolution: "@babel/types@npm:7.28.5"
@@ -1709,13 +1752,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/types@npm:7.28.6"
+"@babel/types@npm:^8.0.0-rc.2, @babel/types@npm:^8.0.0-rc.4":
+  version: 8.0.0-rc.4
+  resolution: "@babel/types@npm:8.0.0-rc.4"
   dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-  checksum: 10/f9c6e52b451065aae5654686ecfc7de2d27dd0fbbc204ee2bd912a71daa359521a32f378981b1cf333ace6c8f86928814452cb9f388a7da59ad468038deb6b5f
+    "@babel/helper-string-parser": "npm:^8.0.0-rc.4"
+    "@babel/helper-validator-identifier": "npm:^8.0.0-rc.4"
+  checksum: 10/4d913640007fdb994e8ce3ca59a0640fde53f0a2358f801f2123c4b05c9f4d2c8836db8fbc7e4d5c1bb9bc5bc99805e6d92aac697c870518e93a18125b526c54
   languageName: node
   linkType: hard
 
@@ -1756,33 +1799,75 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@buildonspark/bare@npm:0.0.42, @buildonspark/bare@workspace:packages/bare":
+"@buildonspark/bare@npm:0.0.67, @buildonspark/bare@workspace:packages/bare":
   version: 0.0.0-use.local
   resolution: "@buildonspark/bare@workspace:packages/bare"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
-    "@buildonspark/spark-frost-bare-addon": "npm:0.0.6"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/spark-frost-bare-addon": "npm:0.0.11"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@noble/hashes": "npm:^1.7.0"
-    bare-node-runtime: "npm:^1.1.4"
+    bare: "npm:^1.28.4"
+    bare-node-runtime: "npm:^1.2.0"
+    bare-runtime: "npm:^1.28.4"
     depcheck: "npm:^1.4.7"
     madge: "npm:^8.0.0"
     prettier: "npm:^3.7.4"
     publint: "npm:^0.3.9"
-    tsdown: "npm:^0.20.0-beta.3"
+    tsdown: "npm:^0.20.3"
     typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
 
-"@buildonspark/interactive-cli@workspace:examples/interactive-cli":
+"@buildonspark/cli@workspace:apps/spark-cli":
   version: 0.0.0-use.local
-  resolution: "@buildonspark/interactive-cli@workspace:examples/interactive-cli"
+  resolution: "@buildonspark/cli@workspace:apps/spark-cli"
+  dependencies:
+    "@buildonspark/issuer-sdk": "npm:0.1.35"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
+    "@lightsparkdev/core": "npm:^1.5.0"
+    "@noble/curves": "npm:^1.9.7"
+    "@noble/hashes": "npm:^1.7.0"
+    "@scure/base": "npm:^1.2.4"
+    "@scure/btc-signer": "npm:^1.5.0"
+    "@types/node": "npm:^22.13.2"
+    cross-env: "npm:^7.0.3"
+    prettier: "npm:^3.7.4"
+    tsdown: "npm:^0.20.3"
+    tsx: "npm:^4.19.3"
+    typescript: "npm:^5.7.3"
+    yargs: "npm:^18.0.0"
+  bin:
+    spark-cli: ./dist/cli.js
+  languageName: unknown
+  linkType: soft
+
+"@buildonspark/create-spark-app@workspace:apps/create-spark-app":
+  version: 0.0.0-use.local
+  resolution: "@buildonspark/create-spark-app@workspace:apps/create-spark-app"
+  dependencies:
+    "@arethetypeswrong/cli": "npm:^0.17.4"
+    "@inquirer/prompts": "npm:^7.0.0"
+    "@types/node": "npm:^22.13.2"
+    prettier: "npm:^3.7.4"
+    publint: "npm:^0.3.9"
+    tar: "npm:^7.0.0"
+    tsdown: "npm:^0.20.3"
+    typescript: "npm:^5.7.3"
+  bin:
+    create-spark-app: ./dist/index.cjs
+  languageName: unknown
+  linkType: soft
+
+"@buildonspark/interactive-cli@workspace:apps/interactive-cli":
+  version: 0.0.0-use.local
+  resolution: "@buildonspark/interactive-cli@workspace:apps/interactive-cli"
   dependencies:
     "@babel/cli": "npm:^7.27.1"
     "@babel/core": "npm:^7.27.3"
     "@babel/preset-react": "npm:^7.27.1"
     "@babel/preset-typescript": "npm:^7.27.1"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@types/node": "npm:^22.13.2"
     "@types/react": "npm:^19.0.10"
     ink: "npm:^6.6.0"
@@ -1792,19 +1877,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@buildonspark/issuer-sdk@npm:0.1.13, @buildonspark/issuer-sdk@workspace:packages/issuer-sdk":
+"@buildonspark/issuer-sdk@npm:0.1.35, @buildonspark/issuer-sdk@workspace:packages/issuer-sdk":
   version: 0.0.0-use.local
   resolution: "@buildonspark/issuer-sdk@workspace:packages/issuer-sdk"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@jest/globals": "npm:^29.7.0"
-    "@noble/curves": "npm:^1.8.0"
+    "@lightsparkdev/eslint-config": "npm:^0.0.1"
+    "@noble/curves": "npm:^1.9.7"
     "@scure/btc-signer": "npm:^1.5.0"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.13.2"
     buffer: "npm:^6.0.3"
     depcheck: "npm:^1.4.7"
+    eslint: "npm:^9.25.0"
+    eslint-watch: "npm:^8.0.0"
     jest: "npm:^29.7.0"
     madge: "npm:^8.0.0"
     node-fetch: "npm:^3.3.2"
@@ -1814,7 +1902,7 @@ __metadata:
     react-native: "npm:0.79.4"
     react-native-get-random-values: "npm:^1.11.0"
     ts-jest: "npm:^29.2.5"
-    tsdown: "npm:^0.20.0-beta.3"
+    tsdown: "npm:^0.20.3"
     typescript: "npm:^5.7.3"
   peerDependencies:
     react: ">=18.2.0"
@@ -1830,11 +1918,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@buildonspark/lrc20-l1-announcer@workspace:apps/lrc20-l1-announcer":
+  version: 0.0.0-use.local
+  resolution: "@buildonspark/lrc20-l1-announcer@workspace:apps/lrc20-l1-announcer"
+  dependencies:
+    "@bitcoinerlab/secp256k1": "npm:^1.1.1"
+    "@types/node": "npm:^22.13.2"
+    bitcoinjs-lib: "npm:^6.1.5"
+    ecpair: "npm:^2.1.0"
+    node-fetch: "npm:^3.3.2"
+    prettier: "npm:^3.7.4"
+    tsx: "npm:^4.19.3"
+    typescript: "npm:^5.7.3"
+  bin:
+    announce-token: announce-token.ts
+  languageName: unknown
+  linkType: soft
+
 "@buildonspark/nestjs-app@workspace:examples/nestjs-app":
   version: 0.0.0-use.local
   resolution: "@buildonspark/nestjs-app@workspace:examples/nestjs-app"
   dependencies:
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@nestjs/cli": "npm:^10.0.0"
     "@nestjs/common": "npm:^10.0.0"
     "@nestjs/core": "npm:^10.0.0"
@@ -1870,10 +1975,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@buildonspark/nodejs-scripts@workspace:examples/nodejs-scripts"
   dependencies:
-    "@buildonspark/issuer-sdk": "npm:0.1.13"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/issuer-sdk": "npm:0.1.35"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.13.2"
+    cross-env: "npm:^7.0.3"
     jest: "npm:^29.7.0"
     prettier: "npm:^3.7.4"
     ts-jest: "npm:^29.2.5"
@@ -1886,25 +1992,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@buildonspark/spark-bare-app@workspace:examples/spark-bare-app"
   dependencies:
-    "@buildonspark/bare": "npm:0.0.42"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
-    bare: "npm:^1.23.3"
-    prettier: "npm:^3.7.4"
-  languageName: unknown
-  linkType: soft
-
-"@buildonspark/spark-cli@workspace:examples/spark-cli":
-  version: 0.0.0-use.local
-  resolution: "@buildonspark/spark-cli@workspace:examples/spark-cli"
-  dependencies:
-    "@buildonspark/issuer-sdk": "npm:0.1.13"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
-    "@types/node": "npm:^22.13.2"
+    "@buildonspark/bare": "npm:0.0.67"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
+    bare: "npm:^1.28.4"
+    bare-http1: "npm:^4.5.2"
+    bare-https: "npm:^3.0.0"
+    bare-runtime: "npm:^1.28.4"
     cross-env: "npm:^7.0.3"
     prettier: "npm:^3.7.4"
-    tsx: "npm:^4.19.3"
-    typescript: "npm:^5.7.3"
-    yargs: "npm:^18.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1912,9 +2007,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@buildonspark/spark-expo-react-native-app@workspace:examples/spark-expo-react-native-app"
   dependencies:
+    "@azure/core-asynciterator-polyfill": "npm:^1.0.2"
     "@babel/core": "npm:^7.27.3"
     "@babel/plugin-transform-class-static-block": "npm:^7.28.3"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/issuer-sdk": "npm:0.1.35"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@expo/vector-icons": "npm:^14.1.0"
     "@react-native-community/cli": "npm:19.0.0"
     "@react-navigation/bottom-tabs": "npm:^7.4.8"
@@ -1922,6 +2019,7 @@ __metadata:
     "@react-navigation/native": "npm:^7.1.18"
     "@types/react": "npm:^19.0.10"
     "@types/react-native-get-random-values": "npm:^1"
+    "@types/text-encoding": "npm:^0"
     eslint: "npm:^9.25.0"
     eslint-config-expo: "npm:~9.2.0"
     expo: "npm:53.0.13"
@@ -1943,31 +2041,54 @@ __metadata:
     react-native: "npm:0.79.4"
     react-native-gesture-handler: "npm:~2.24.0"
     react-native-get-random-values: "npm:^1.11.0"
+    react-native-keyboard-aware-scroll-view: "npm:^0.9.5"
     react-native-reanimated: "npm:~3.17.4"
     react-native-safe-area-context: "npm:^5.6.1"
-    react-native-screens: "npm:^4.16.0"
+    react-native-screens: "npm:~4.18.0"
     react-native-web: "npm:~0.20.0"
     react-native-webview: "npm:13.13.5"
+    text-encoding: "npm:^0.7.0"
     typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
 
-"@buildonspark/spark-frost-bare-addon@npm:0.0.6, @buildonspark/spark-frost-bare-addon@workspace:packages/spark-frost-bare-addon":
+"@buildonspark/spark-frost-bare-addon@npm:0.0.11, @buildonspark/spark-frost-bare-addon@workspace:packages/spark-frost-bare-addon":
   version: 0.0.0-use.local
   resolution: "@buildonspark/spark-frost-bare-addon@workspace:packages/spark-frost-bare-addon"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
-    "@noble/curves": "npm:^1.8.0"
+    "@noble/curves": "npm:^1.9.7"
     "@noble/secp256k1": "npm:^2.3.0"
-    bare: "npm:^1.23.3"
+    bare: "npm:^1.28.4"
     bare-make: "npm:^1.5.1"
-    bare-node-runtime: "npm:^1.1.4"
+    bare-node-runtime: "npm:^1.2.0"
+    bare-runtime: "npm:^1.28.4"
     cmake-bare: "npm:^1.6.5"
     cmake-cargo: "npm:^0.0.5"
     cmake-npm: "npm:^1.1.0"
     prettier: "npm:^3.7.4"
     prettier-config-standard: "npm:^7.0.0"
     publint: "npm:^0.3.9"
+  languageName: unknown
+  linkType: soft
+
+"@buildonspark/spark-mcp@workspace:packages/spark-mcp":
+  version: 0.0.0-use.local
+  resolution: "@buildonspark/spark-mcp@workspace:packages/spark-mcp"
+  dependencies:
+    "@buildonspark/spark-sdk": "workspace:*"
+    "@jest/globals": "npm:^29.7.0"
+    "@modelcontextprotocol/sdk": "npm:^1.10.0"
+    "@types/jest": "npm:^29.5.14"
+    "@types/node": "npm:^22.13.2"
+    jest: "npm:^29.7.0"
+    prettier: "npm:^3.7.4"
+    ts-jest: "npm:^29.2.5"
+    tsdown: "npm:^0.20.3"
+    typescript: "npm:^5.7.3"
+    zod: "npm:^3.24.0"
+  bin:
+    spark-mcp: ./dist/index.js
   languageName: unknown
   linkType: soft
 
@@ -1980,8 +2101,8 @@ __metadata:
     "@babel/plugin-transform-class-static-block": "npm:^7.28.3"
     "@babel/preset-env": "npm:^7.27.2"
     "@babel/runtime": "npm:^7.25.0"
-    "@buildonspark/issuer-sdk": "npm:0.1.13"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/issuer-sdk": "npm:0.1.35"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@react-native-community/cli": "npm:19.0.0"
     "@react-native-community/cli-platform-android": "npm:19.0.0"
     "@react-native-community/cli-platform-ios": "npm:19.0.0"
@@ -2008,31 +2129,24 @@ __metadata:
     react-native-get-random-values: "npm:^1.11.0"
     react-native-keyboard-aware-scroll-view: "npm:^0.9.5"
     react-native-safe-area-context: "npm:^5.6.1"
-    react-native-screens: "npm:^4.16.0"
+    react-native-screens: "npm:~4.18.0"
     react-test-renderer: "npm:19.0.0"
     text-encoding: "npm:^0.7.0"
     typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
 
-"@buildonspark/spark-sdk@npm:0.6.3, @buildonspark/spark-sdk@workspace:packages/spark-sdk":
+"@buildonspark/spark-sdk@npm:0.7.17, @buildonspark/spark-sdk@workspace:*, @buildonspark/spark-sdk@workspace:packages/spark-sdk":
   version: 0.0.0-use.local
   resolution: "@buildonspark/spark-sdk@workspace:packages/spark-sdk"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@bufbuild/protobuf": "npm:^2.2.5"
     "@jest/globals": "npm:^29.7.0"
-    "@lightsparkdev/core": "npm:^1.4.4"
-    "@noble/curves": "npm:^1.8.0"
+    "@lightsparkdev/core": "npm:^1.5.0"
+    "@lightsparkdev/eslint-config": "npm:^0.0.1"
+    "@noble/curves": "npm:^1.9.7"
     "@noble/hashes": "npm:^1.7.0"
-    "@opentelemetry/api": "npm:^1.9.0"
-    "@opentelemetry/context-async-hooks": "npm:^2.0.0"
-    "@opentelemetry/core": "npm:^2.0.0"
-    "@opentelemetry/instrumentation": "npm:^0.203.0"
-    "@opentelemetry/instrumentation-undici": "npm:^0.14.0"
-    "@opentelemetry/sdk-trace-base": "npm:^2.0.0"
-    "@opentelemetry/sdk-trace-node": "npm:^2.0.1"
-    "@opentelemetry/sdk-trace-web": "npm:^2.0.1"
     "@scure/base": "npm:^1.2.4"
     "@scure/bip32": "npm:^1.6.2"
     "@scure/bip39": "npm:^1.5.4"
@@ -2043,9 +2157,11 @@ __metadata:
     abortcontroller-polyfill: "npm:^1.7.8"
     async-mutex: "npm:^0.5.0"
     bare-crypto: "npm:^1.9.2"
-    bare-fetch: "npm:^2.4.1"
+    bare-fetch: "npm:^3.0.0"
     buffer: "npm:^6.0.3"
     depcheck: "npm:^1.4.7"
+    eslint: "npm:^9.25.0"
+    eslint-watch: "npm:^8.0.0"
     eventemitter3: "npm:^5.0.1"
     jest: "npm:^29.7.0"
     js-base64: "npm:^3.7.7"
@@ -2054,7 +2170,6 @@ __metadata:
     nice-grpc: "npm:^2.1.10"
     nice-grpc-client-middleware-retry: "npm:^3.1.10"
     nice-grpc-common: "npm:^2.0.2"
-    nice-grpc-opentelemetry: "npm:^0.1.18"
     nice-grpc-web: "npm:^3.3.7"
     node-fetch: "npm:^3.3.2"
     prettier: "npm:^3.7.4"
@@ -2064,7 +2179,7 @@ __metadata:
     react-native-get-random-values: "npm:^1.11.0"
     ts-jest: "npm:^29.2.5"
     ts-proto: "npm:2.8.3"
-    tsdown: "npm:^0.20.0-beta.3"
+    tsdown: "npm:^0.20.3"
     typescript: "npm:^5.7.3"
     ua-parser-js: "npm:^2.0.6"
     uuidv7: "npm:^1.0.2"
@@ -2082,31 +2197,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@buildonspark/spark-token-cli@workspace:examples/spark-token-cli":
-  version: 0.0.0-use.local
-  resolution: "@buildonspark/spark-token-cli@workspace:examples/spark-token-cli"
-  dependencies:
-    "@bitcoinerlab/secp256k1": "npm:^1.1.1"
-    "@types/node": "npm:^22.13.2"
-    bitcoinjs-lib: "npm:^6.1.5"
-    ecpair: "npm:^2.1.0"
-    node-fetch: "npm:^3.3.2"
-    prettier: "npm:^3.7.4"
-    tsx: "npm:^4.19.3"
-    typescript: "npm:^5.7.3"
-  bin:
-    announce-token: announce-token.ts
-  languageName: unknown
-  linkType: soft
-
 "@buildonspark/spark-vite-app@workspace:examples/spark-vite-app":
   version: 0.0.0-use.local
   resolution: "@buildonspark/spark-vite-app@workspace:examples/spark-vite-app"
   dependencies:
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@types/react": "npm:^19.0.10"
     "@types/react-dom": "npm:^19.1.5"
     "@vitejs/plugin-react": "npm:^4.3.4"
+    cross-env: "npm:^7.0.3"
     globals: "npm:^15.15.0"
     prettier: "npm:^3.7.4"
     react: "npm:19.0.0"
@@ -2410,6 +2509,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/core@npm:1.10.0"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10/d32f386084e64deaf2609aabb8295d1ad5af6144d0f46d2060b76cc53f1f3b486df54bec9b0f33c37d85a3822e1193ebcd4e3deb4a5f0e4cd650aa2ffc631715
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.4.3, @emnapi/core@npm:^1.6.0, @emnapi/core@npm:^1.7.1":
   version: 1.7.1
   resolution: "@emnapi/core@npm:1.7.1"
@@ -2417,6 +2526,15 @@ __metadata:
     "@emnapi/wasi-threads": "npm:1.1.0"
     tslib: "npm:^2.4.0"
   checksum: 10/260841f6dd2a7823a964d9de6da3a5e6f565dac8d21a5bd8f6215b87c45c22a4dc371b9ad877961579ee3cca8a76e55e3dd033ae29cba1998999cda6d794bdab
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/runtime@npm:1.10.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/d21083d07fa0c2da171c142e78ef986b66b07d45b06accc0bcaf49fcc61bb4dbc10e1c1760813070165b9f49b054376a931045347f21c0f42ff1eb2d2040faac
   languageName: node
   linkType: hard
 
@@ -2435,6 +2553,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/0d557e75262d2f4c95cb2a456ba0785ef61f919ce488c1d76e5e3acfd26e00c753ef928cd80068363e0c166ba8cc0141305daf0f81aad5afcd421f38f11e0f4e
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@emnapi/wasi-threads@npm:1.2.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/57cd4292be81c05d26aa886d68a9e4c449ff666e8503fed6463dfc6b64a4e4213f03c152d53296b7cda32840271e38cd33347332070658f01befeb9bf4e59f36
   languageName: node
   linkType: hard
 
@@ -2813,7 +2940,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.10.0, @eslint-community/regexpp@npm:^4.12.1":
+"@eslint-community/eslint-utils@npm:^4.9.1":
+  version: 4.9.1
+  resolution: "@eslint-community/eslint-utils@npm:4.9.1"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.4.3"
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: 10/863b5467868551c9ae34d03eefe634633d08f623fc7b19d860f8f26eb6f303c1a5934253124163bee96181e45ed22bf27473dccc295937c3078493a4a8c9eddd
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.10.0, @eslint-community/regexpp@npm:^4.12.1, @eslint-community/regexpp@npm:^4.12.2":
   version: 4.12.2
   resolution: "@eslint-community/regexpp@npm:4.12.2"
   checksum: 10/049b280fddf71dd325514e0a520024969431dc3a8b02fa77476e6820e9122f28ab4c9168c11821f91a27982d2453bcd7a66193356ea84e84fb7c8d793be1ba0c
@@ -2870,6 +3008,13 @@ __metadata:
   version: 9.39.1
   resolution: "@eslint/js@npm:9.39.1"
   checksum: 10/b10b9b953212c0f3ffca475159bbe519e9e98847200c7432d1637d444fddcd7b712d2b7710a7dc20510f9cfbe8db330039b2aad09cb55d9545b116d940dbeed2
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:^9.0.0":
+  version: 9.39.4
+  resolution: "@eslint/js@npm:9.39.4"
+  checksum: 10/0a7ab4c4108cf2cadf66849ebd20f5957cc53052b88d8807d0b54e489dbf6ffcaf741e144e7f9b187c395499ce2e6ddc565dbfa4f60c6df455cf2b30bcbdc5a3
   languageName: node
   linkType: hard
 
@@ -3409,6 +3554,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hono/node-server@npm:^1.19.9":
+  version: 1.19.14
+  resolution: "@hono/node-server@npm:1.19.14"
+  peerDependencies:
+    hono: ^4
+  checksum: 10/618dd95feeb3fd11ec8502e088879cd86529523788de19602edebd16892dd61899e73564d6e3d00875cc5a49488a908ddb2aa425d28f9cdeb7f22cfecabf022c
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -3667,7 +3821,100 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/external-editor@npm:^1.0.2":
+"@inquirer/ansi@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@inquirer/ansi@npm:1.0.2"
+  checksum: 10/d1496e573a63ee6752bcf3fc93375cdabc55b0d60f0588fe7902282c710b223252ad318ff600ee904e48555634663b53fda517f5b29ce9fbda90bfae18592fbc
+  languageName: node
+  linkType: hard
+
+"@inquirer/checkbox@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@inquirer/checkbox@npm:4.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/4ac5dd2679981e23f066c51c605cb1c63ccda9ea6e1ad895e675eb26702aaf6cf961bf5ca3acd832efba5edcf9883b6742002c801673d2b35c123a7fa7db7b23
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.1.21":
+  version: 5.1.21
+  resolution: "@inquirer/confirm@npm:5.1.21"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/a107aa0073965ea510affb9e5b55baf40333503d600970c458c07770cd4e0eee01efc4caba66f0409b0fadc9550d127329622efb543cffcabff3ad0e7f865372
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^10.3.2":
+  version: 10.3.2
+  resolution: "@inquirer/core@npm:10.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/eb434bdf0ae7d904367003c772bcd80cbf679f79c087c99a4949fd7288e9a2f713ec3ea63381b9a001f52389ab56a77fcd88d64d81a03b1195193410ce8971c2
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^4.2.23":
+  version: 4.2.23
+  resolution: "@inquirer/editor@npm:4.2.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/external-editor": "npm:^1.0.3"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/f91b9aadba6ea28a0f4ea5f075af421e076262aebbd737e1b9779f086fa9d559d064e9942a581544645d1dcf56d6b685e8063fe46677880fbca73f6de4e4e7c5
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/expand@npm:4.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/73ad1d6376e5efe2a452c33494d6d16ee2670c638ae470a795fdff4acb59a8e032e38e141f87b603b6e96320977519b375dac6471d86d5e3087a9c1db40e3111
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^1.0.2, @inquirer/external-editor@npm:^1.0.3":
   version: 1.0.3
   resolution: "@inquirer/external-editor@npm:1.0.3"
   dependencies:
@@ -3679,6 +3926,145 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10/c95d7237a885b32031715089f92820525731d4d3c2bd7afdb826307dc296cc2b39e7a644b0bb265441963348cca42e7785feb29c3aaf18fd2b63131769bf6587
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.15":
+  version: 1.0.15
+  resolution: "@inquirer/figures@npm:1.0.15"
+  checksum: 10/3f858807f361ca29f41ec1076bbece4098cc140d86a06159d42c6e3f6e4d9bec9e10871ccfcbbaa367d6a8462b01dff89f2b1b157d9de6e8726bec85533f525c
+  languageName: node
+  linkType: hard
+
+"@inquirer/input@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@inquirer/input@npm:4.3.1"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/713aaa4c94263299fbd7adfd65378f788cac1b5047f2b7e1ea349ca669db6c7c91b69ab6e2f6660cdbc28c7f7888c5c77ab4433bd149931597e43976d1ba5f34
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^3.0.23":
+  version: 3.0.23
+  resolution: "@inquirer/number@npm:3.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/50694807b71746e15ed69d100aae3c8014d83c90aa660e8a179fe0db1046f26d727947542f64e24cc8b969a61659cb89fe36208cc2b59c1816382b598e686dd2
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/password@npm:4.0.23"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/97364970b01c85946a4a50ad876c53ef0c1857a9144e24fad65e5dfa4b4e5dd42564fbcdfa2b49bb049a25d127efbe0882cb18afcdd47b166ebd01c6c4b5e825
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^7.0.0":
+  version: 7.10.1
+  resolution: "@inquirer/prompts@npm:7.10.1"
+  dependencies:
+    "@inquirer/checkbox": "npm:^4.3.2"
+    "@inquirer/confirm": "npm:^5.1.21"
+    "@inquirer/editor": "npm:^4.2.23"
+    "@inquirer/expand": "npm:^4.0.23"
+    "@inquirer/input": "npm:^4.3.1"
+    "@inquirer/number": "npm:^3.0.23"
+    "@inquirer/password": "npm:^4.0.23"
+    "@inquirer/rawlist": "npm:^4.1.11"
+    "@inquirer/search": "npm:^3.2.2"
+    "@inquirer/select": "npm:^4.4.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/b3e3386edd255e4e91c7908050674f8a2e69b043883c00feec2f87d697be37bc6e8cd4a360e7e3233a9825ae7ea044a2ac63d5700926d27f9959013d8566f890
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "@inquirer/rawlist@npm:4.1.11"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/0d8f6484cfc20749190e95eecfb2d034bafb3644ec4907b84b1673646f5dd71730e38e35565ea98dfd240d8851e3cff653edafcc4e0af617054b127b407e3229
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@inquirer/search@npm:3.2.2"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/abaed2df7763633ff4414b58d1c87233b69ed3cd2ac77629f0d54b72b8b585dc4806c7a2a8261daba58af5b0a2147e586d079fdc82060b6bcf56b75d3d03f3a7
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@inquirer/select@npm:4.4.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/795ec0ac77d575f20bd6a12fb1c040093e62217ac0c80194829a8d3c3d1e09f70ad738e9a9dd6095cc8358fff4e13882209c09bdf8eb0864a86dcabef5b0a6a6
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@inquirer/type@npm:3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/57d113a9db7abc73326491e29bedc88ef362e53779f9f58a1b61225e0be068ce0c54e33cd65f4a13ca46131676fb72c3ef488463c4c9af0aa89680684c55d74c
   languageName: node
   linkType: hard
 
@@ -4147,17 +4533,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lightsparkdev/core@npm:^1.4.4":
-  version: 1.4.6
-  resolution: "@lightsparkdev/core@npm:1.4.6"
+"@lightsparkdev/core@npm:^1.5.0":
+  version: 1.5.2
+  resolution: "@lightsparkdev/core@npm:1.5.2"
   dependencies:
+    "@noble/curves": "npm:^1.9.7"
     dayjs: "npm:^1.11.7"
     graphql: "npm:^16.6.0"
     graphql-ws: "npm:^5.11.3"
-    secp256k1: "npm:^5.0.1"
     ws: "npm:^8.12.1"
     zen-observable-ts: "npm:^1.1.0"
-  checksum: 10/62c6b56c89a90c7cf4ebdd2198b555b60a28bf3c3f7403d38d71ed1eec96706c4d00fc2eb530ebc45c43fd7ba118201ae4af7cef6182bc6ab843d398ee5d8064
+  checksum: 10/6e4d93ec477e4cf09cf7bb30142174a3a332db3104b19e896561928f695304654f656d203c231cb165934caea7fd83fe4bb40fce90d43794ef34793139e27fb7
+  languageName: node
+  linkType: hard
+
+"@lightsparkdev/eslint-config@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@lightsparkdev/eslint-config@npm:0.0.1"
+  dependencies:
+    "@eslint/js": "npm:^9.0.0"
+    confusing-browser-globals: "npm:^1.0.11"
+    eslint-plugin-comment-length: "npm:^1.7.2"
+    eslint-plugin-import: "npm:^2.29.0"
+    eslint-plugin-jest: "npm:^29.15.0"
+    eslint-plugin-jsx-a11y: "npm:^6.8.0"
+    eslint-plugin-react: "npm:^7.34.0"
+    eslint-plugin-react-hooks: "npm:^5.0.0"
+    eslint-plugin-testing-library: "npm:^6.0.2"
+    globals: "npm:^15.0.0"
+    typescript-eslint: "npm:^8.0.0"
+  peerDependencies:
+    eslint: ^9.0.0
+    typescript: ">=5.0.0"
+  checksum: 10/04487b6756278ca9286ad40a4883bac7b9e469690852f176d5b4ba25756567742b09970b17a4bd992a325a03dd64bd3cf7047e3f2adc7badecc5f4368241b3c4
   languageName: node
   linkType: hard
 
@@ -4263,6 +4671,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@modelcontextprotocol/sdk@npm:^1.10.0":
+  version: 1.29.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.9"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.2.1"
+    hono: "npm:^4.11.4"
+    jose: "npm:^6.1.3"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 10/ff551b97e06b661f95fec8fd34e112c446e69894a84a9979cdac369fb5de27f0a1a5c1f4e2a1f270cc60f93e54c28a8059a94ca51c3d528d2670ade874b244f9
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^0.2.11":
   version: 0.2.12
   resolution: "@napi-rs/wasm-runtime@npm:0.2.12"
@@ -4293,6 +4734,18 @@ __metadata:
     "@emnapi/runtime": "npm:^1.7.1"
     "@tybys/wasm-util": "npm:^0.10.1"
   checksum: 10/080e7f2aefb84e09884d21c650a2cbafdf25bfd2634693791b27e36eec0ddaa3c1656a943f8c913ac75879a0b04e68f8a827897ee655ab54a93169accf05b194
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10/1db3dc7eeb981306b09360487bd8ce4dfa5588d273bd8ea9f07dccca1b4ade57b675414180fc9bb66966c6c50b17208b0263194993e2f7f92cc7af28bda4d1af
   languageName: node
   linkType: hard
 
@@ -4521,7 +4974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:^1.7.0, @noble/curves@npm:^1.8.0, @noble/curves@npm:~1.9.0":
+"@noble/curves@npm:^1.7.0, @noble/curves@npm:^1.9.7, @noble/curves@npm:~1.9.0":
   version: 1.9.7
   resolution: "@noble/curves@npm:1.9.7"
   dependencies:
@@ -4922,128 +5375,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api-logs@npm:0.203.0":
-  version: 0.203.0
-  resolution: "@opentelemetry/api-logs@npm:0.203.0"
-  dependencies:
-    "@opentelemetry/api": "npm:^1.3.0"
-  checksum: 10/e8c890cbf36f1a458ff4fc13c0d2efc81ea8f173d124d06e6878c539f2e84517013c1e2fd4b7149a3f88ba1a3b5befeb8068edea7f391c5d69fb8b02a2a13bc0
+"@oxc-project/types@npm:=0.112.0":
+  version: 0.112.0
+  resolution: "@oxc-project/types@npm:0.112.0"
+  checksum: 10/59549821692604d6715791bb28f06c973e9664fc3a08b0b992b3079058f66c5b9b5ce8c63fd0056ff4da2c6943eaf71ff071c9bad1cb4ee2346d388014c7ec9e
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.8.0, @opentelemetry/api@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "@opentelemetry/api@npm:1.9.0"
-  checksum: 10/a607f0eef971893c4f2ee2a4c2069aade6ec3e84e2a1f5c2aac19f65c5d9eeea41aa72db917c1029faafdd71789a1a040bdc18f40d63690e22ccae5d7070f194
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/context-async-hooks@npm:2.2.0, @opentelemetry/context-async-hooks@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "@opentelemetry/context-async-hooks@npm:2.2.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10/00ee1a35ce9f96632955830d54672025db6d4dc77d440c183cd9751efd5bdfeb8a078094d3d1caaf8b3c250def098990a98bfd8254b1ec04b759f1e3f2fc224e
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/core@npm:2.2.0, @opentelemetry/core@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "@opentelemetry/core@npm:2.2.0"
-  dependencies:
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10/f25193ba8b1fadb7bd8ed0d86ac39dd0f3fd3eec47c2fb2745bd22442b2d5e3ca88e5cab6d97111349d3182bf8e4356f8b7c7213ebea8f7719de944ce13a19cb
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/instrumentation-undici@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@opentelemetry/instrumentation-undici@npm:0.14.0"
-  dependencies:
-    "@opentelemetry/core": "npm:^2.0.0"
-    "@opentelemetry/instrumentation": "npm:^0.203.0"
-  peerDependencies:
-    "@opentelemetry/api": ^1.7.0
-  checksum: 10/05527080bd54aa59790c596307e238333e3046fc9507bcc645e53f9330ddae51b834f2b29760af978a2966b945ec8647456e4fbc09fb8addbb38aedf05004f8b
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/instrumentation@npm:^0.203.0":
-  version: 0.203.0
-  resolution: "@opentelemetry/instrumentation@npm:0.203.0"
-  dependencies:
-    "@opentelemetry/api-logs": "npm:0.203.0"
-    import-in-the-middle: "npm:^1.8.1"
-    require-in-the-middle: "npm:^7.1.1"
-  peerDependencies:
-    "@opentelemetry/api": ^1.3.0
-  checksum: 10/0e85cd7df97e4a7a9cdd23d187be45dae93806bf04783c531fe847cc4b24abd96934ad1196320661190648444d726bed1f702fa96e0af3fc7edb3c04c44fde34
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/resources@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@opentelemetry/resources@npm:2.2.0"
-  dependencies:
-    "@opentelemetry/core": "npm:2.2.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.3.0 <1.10.0"
-  checksum: 10/65ccdb1de957dc89aef252cf84b73cd0257ec44feec2b513fcf08e8c4d03e97275661d3f60c4b6134cee33ca4359a5ab6ef5d3a97339a3585aa997a381ef9098
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/sdk-trace-base@npm:2.2.0, @opentelemetry/sdk-trace-base@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "@opentelemetry/sdk-trace-base@npm:2.2.0"
-  dependencies:
-    "@opentelemetry/core": "npm:2.2.0"
-    "@opentelemetry/resources": "npm:2.2.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.3.0 <1.10.0"
-  checksum: 10/0838128f965055b5f8d37026a2f4736ebb77a772a94b9f5b7accb0447a44cfa279da4da959a82565e958e1676ad2a02c17f6fd0e688b205bdde0c846e310c643
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/sdk-trace-node@npm:^2.0.1":
-  version: 2.2.0
-  resolution: "@opentelemetry/sdk-trace-node@npm:2.2.0"
-  dependencies:
-    "@opentelemetry/context-async-hooks": "npm:2.2.0"
-    "@opentelemetry/core": "npm:2.2.0"
-    "@opentelemetry/sdk-trace-base": "npm:2.2.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10/4918bc6a66649203d7165a8beca5a3ebaf05d91a2b4910aa195f582a6b50658e86303e00a4fc53172e48cac3cc79b50906d70a3b989895b423dc90dad5e9b5da
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/sdk-trace-web@npm:^2.0.1":
-  version: 2.2.0
-  resolution: "@opentelemetry/sdk-trace-web@npm:2.2.0"
-  dependencies:
-    "@opentelemetry/core": "npm:2.2.0"
-    "@opentelemetry/sdk-trace-base": "npm:2.2.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10/174694fd1582ebef06d6311ddafbb44160836e5c519a5f25b386307c9ec1856b9d15f3a98ea38f12f74c121cff732f0c978809a91265a9f1574db9cdbb128636
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/semantic-conventions@npm:^1.22.0, @opentelemetry/semantic-conventions@npm:^1.29.0":
-  version: 1.38.0
-  resolution: "@opentelemetry/semantic-conventions@npm:1.38.0"
-  checksum: 10/9d549f4896e900f644d5e70dd7142505daff88ed83c1cb7bcd976ac55e9496d4ddd686bb2815dd68655c739950514394c3b73ff51e53b2e4ff2d54a7f6d22521
-  languageName: node
-  linkType: hard
-
-"@oxc-project/types@npm:=0.108.0":
-  version: 0.108.0
-  resolution: "@oxc-project/types@npm:0.108.0"
-  checksum: 10/b41a88f024202c415aa1f595764c088e784b0b6e08278413ed194dc26b69a0ab9b8e840f0397dcf64e8298d1f61419a8e199e1763bd79e376ce1baf8e3aabac5
+"@oxc-project/types@npm:=0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-project/types@npm:0.127.0"
+  checksum: 10/f154f4720367186aed63a16fb1395f9039d4e6872265fe9e6b5eacc02fb2b948f9ea6c5f85efd3a015ea28aa8c31232b7a8301218ae28651659e46dd0c4f2031
   languageName: node
   linkType: hard
 
@@ -5895,95 +6237,204 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-beta.60"
+"@rolldown/binding-android-arm64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.17"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-beta.60"
+"@rolldown/binding-android-arm64@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.3"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.17"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-beta.60"
+"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.17"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-beta.60"
+"@rolldown/binding-darwin-x64@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.17"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.60"
+"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.3"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.60"
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.60"
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.60"
+"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.60"
+"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-beta.60"
+"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.60"
+"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.3"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.17"
+  dependencies:
+    "@emnapi/core": "npm:1.10.0"
+    "@emnapi/runtime": "npm:1.10.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.4"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.3"
   dependencies:
     "@napi-rs/wasm-runtime": "npm:^1.1.1"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.60"
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.17"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.60"
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5995,10 +6446,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.60"
-  checksum: 10/9dbbd9ccce57950182ede6c3f8dd69d551dcc801e4ef2e32bcde14c487b07647dfa25f09bc8c60b4c3b59fc3fb27927553df4a4e780112b1b03842cf542d7432
+"@rolldown/pluginutils@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.17"
+  checksum: 10/d659ea756ee6d360a015708d1035c07047e08db99a4160c74c7f22a7ece5611efcc18ad56db4a63b69edb506ded47596d9c0d301919242470d8c412d916b9750
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.3"
+  checksum: 10/b181a693b70e0e5de736458d46b31f72862cd7f36f955656f61ccbf4de11d9206bc3b55404317a65e5714559490444e9fdd83b4097706496e96b082fb584d049
   languageName: node
   linkType: hard
 
@@ -6694,7 +7152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10/25a4c16a6752538ffde2826c2cc0c6491d90e69cd6187bef4a006dd2c3c45469f049e643d7e516c515f21484dc3d48fd5c870be158a5beb72f5baf3dc43e4099
@@ -6845,7 +7303,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/jsesc@npm:^2.5.0":
+  version: 2.5.1
+  resolution: "@types/jsesc@npm:2.5.1"
+  checksum: 10/25407775ed621790d2eec0cc51e194bd0d67a82e39204fd9748899c249ef965e17d9e6560f6c658773714f6d45a259465f3639790bb55750ebb168ee23801596
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10/1a3c3e06236e4c4aab89499c428d585527ce50c24fe8259e8b3926d3df4cfbbbcf306cfc73ddfb66cbafc973116efd15967020b0f738f63e09e64c7d260519e7
@@ -6976,7 +7441,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.3.12":
+"@types/semver@npm:^7.3.12, @types/semver@npm:^7.5.0":
   version: 7.7.1
   resolution: "@types/semver@npm:7.7.1"
   checksum: 10/8f09e7e6ca3ded67d78ba7a8f7535c8d9cf8ced83c52e7f3ac3c281fe8c689c3fe475d199d94390dc04fc681d51f2358b430bb7b2e21c62de24f2bee2c719068
@@ -7118,6 +7583,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.2"
+  dependencies:
+    "@eslint-community/regexpp": "npm:^4.12.2"
+    "@typescript-eslint/scope-manager": "npm:8.59.2"
+    "@typescript-eslint/type-utils": "npm:8.59.2"
+    "@typescript-eslint/utils": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+    ignore: "npm:^7.0.5"
+    natural-compare: "npm:^1.4.0"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    "@typescript-eslint/parser": ^8.59.2
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/c0101b37dac651fbd33e225e84b96cd96e9916257db23ca0e16a611c3fb3f5faaa708f261e3a0440bd5994b6a19a1790f3e39f03ccc25c942137ee64113acf48
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0, @typescript-eslint/eslint-plugin@npm:^8.0.0, @typescript-eslint/eslint-plugin@npm:^8.18.2":
   version: 8.48.1
   resolution: "@typescript-eslint/eslint-plugin@npm:8.48.1"
@@ -7159,6 +7644,22 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/6ee4c61f145dc05f0a567b8ac01b5399ef9c75f58bc6e9a3ffca8927b15e2be2d4c3fd32a2c1a7041cc0848fdeadac30d9cb0d3bcd3835d301847a88ffd19c4d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/parser@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/601eab709a6c7f7273f41b034435cb0a7102ee9e888b154ed9454003fe7b40d8a38286181b1a8ef2b7e4bfa4be6e7a48ee302e715b11d0550550f4ce1a114984
   languageName: node
   linkType: hard
 
@@ -7209,6 +7710,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/project-service@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/project-service@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.59.2"
+    "@typescript-eslint/types": "npm:^8.59.2"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/768d311bdf366519549a3806b16eb3be030328b7cda9882e60ea2a6c112111a531ef94289ec88225b70ca61d2071f1bddf2c5faa841a837d44992c918d198d7b
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/scope-manager@npm:5.62.0"
@@ -7216,6 +7730,16 @@ __metadata:
     "@typescript-eslint/types": "npm:5.62.0"
     "@typescript-eslint/visitor-keys": "npm:5.62.0"
   checksum: 10/e827770baa202223bc0387e2fd24f630690809e460435b7dc9af336c77322290a770d62bd5284260fa881c86074d6a9fd6c97b07382520b115f6786b8ed499da
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/visitor-keys": "npm:6.21.0"
+  checksum: 10/fe91ac52ca8e09356a71dc1a2f2c326480f3cccfec6b2b6d9154c1a90651ab8ea270b07c67df5678956c3bbf0bbe7113ab68f68f21b20912ea528b1214197395
   languageName: node
   linkType: hard
 
@@ -7239,12 +7763,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/scope-manager@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+  checksum: 10/9a63eb5d4ae26235ce2d3348eb45ff0e1a8cc7b198f622c48e921c7bfe0f1f7fa29a8cd3856547a4d42c08b7ed334315c682a714cb3b8b62841b5d59a1d08fd4
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/tsconfig-utils@npm:8.48.1, @typescript-eslint/tsconfig-utils@npm:^8.48.1":
   version: 8.48.1
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.48.1"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
   checksum: 10/830bcd0e7628441f91899e8e24aaed66d32a239babcc205aba1d08c08ff5a636d8c04f96d9873578df59d7468fc4c5df032667764b3b2ee0a733af36fca21c4a
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.59.2, @typescript-eslint/tsconfig-utils@npm:^8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.2"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/42479906a01469322d22e8d45c6200998382f19c1c2dcb59d6adb2e796238a0476f1aa8fd1a1b2c3b36c0c7aa77ebb72ffc958bd11b6efadd36cd175646d13de
   languageName: node
   linkType: hard
 
@@ -7281,10 +7824,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/type-utils@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/type-utils@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/utils": "npm:8.59.2"
+    debug: "npm:^4.4.3"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/931f4fc262722f7cb61bcaf8f3a1cc6aec93690692cb06d37847880f1216fd9183146030b4b313407ae0bb8cda83dbd9e59d0d77dac2cff015f45fb23a0f5911
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/types@npm:5.62.0"
   checksum: 10/24e8443177be84823242d6729d56af2c4b47bfc664dd411a1d730506abf2150d6c31bdefbbc6d97c8f91043e3a50e0c698239dcb145b79bb6b0c34469aaf6c45
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/types@npm:6.21.0"
+  checksum: 10/e26da86d6f36ca5b6ef6322619f8ec55aabcd7d43c840c977ae13ae2c964c3091fc92eb33730d8be08927c9de38466c5323e78bfb270a9ff1d3611fe821046c5
   languageName: node
   linkType: hard
 
@@ -7299,6 +7865,13 @@ __metadata:
   version: 8.48.1
   resolution: "@typescript-eslint/types@npm:8.48.1"
   checksum: 10/1aa1e3f25b429bcebd9eb45b5252d950f1b24dbc6014a47dff8d00547e2e1ac47f351846fb996b6ebd49da37a85394051d36191cbbbf2c431b8db9d95afd198d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.59.2, @typescript-eslint/types@npm:^8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/types@npm:8.59.2"
+  checksum: 10/dc828a5c50debac37047a30ec5bfdc21e2b410c7c8c517c1ab01164fa9a0197f4f6b829f502dd992d21044442277029bfacf0c0b70d7ac9446977cbc8d375e13
   languageName: node
   linkType: hard
 
@@ -7317,6 +7890,25 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/06c975eb5f44b43bd19fadc2e1023c50cf87038fe4c0dd989d4331c67b3ff509b17fa60a3251896668ab4d7322bdc56162a9926971218d2e1a1874d2bef9a52e
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/visitor-keys": "npm:6.21.0"
+    debug: "npm:^4.3.4"
+    globby: "npm:^11.1.0"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:9.0.3"
+    semver: "npm:^7.5.4"
+    ts-api-utils: "npm:^1.0.1"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/b32fa35fca2a229e0f5f06793e5359ff9269f63e9705e858df95d55ca2cd7fdb5b3e75b284095a992c48c5fc46a1431a1a4b6747ede2dd08929dc1cbacc589b8
   languageName: node
   linkType: hard
 
@@ -7358,6 +7950,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/typescript-estree@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.59.2"
+    "@typescript-eslint/tsconfig-utils": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/54a2689e5c08f35364214a542e328745401951e94526c9f95d68b14c57521e9aade1e946074a02ed2c9cc95e94fc1866c3f725f820263759a1ee2072e3ed146f
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:7.18.0":
   version: 7.18.0
   resolution: "@typescript-eslint/utils@npm:7.18.0"
@@ -7387,7 +7998,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:^5.10.0":
+"@typescript-eslint/utils@npm:8.59.2, @typescript-eslint/utils@npm:^8.0.0":
+  version: 8.59.2
+  resolution: "@typescript-eslint/utils@npm:8.59.2"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/4e157a18b28d656b13ae07583765cc871d992abad0ae0aeb2cde819dd632d62b89da9f9e468dfefead18b9440aa2b9040ca36841525dff4ea97479583114afe0
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^5.10.0, @typescript-eslint/utils@npm:^5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/utils@npm:5.62.0"
   dependencies:
@@ -7405,6 +8031,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^6.10.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/utils@npm:6.21.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@types/json-schema": "npm:^7.0.12"
+    "@types/semver": "npm:^7.5.0"
+    "@typescript-eslint/scope-manager": "npm:6.21.0"
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/typescript-estree": "npm:6.21.0"
+    semver: "npm:^7.5.4"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: 10/b404a2c55a425a79d054346ae123087d30c7ecf7ed7abcf680c47bf70c1de4fabadc63434f3f460b2fa63df76bc9e4a0b9fa2383bb8a9fcd62733fb5c4e4f3e3
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
@@ -7412,6 +8055,16 @@ __metadata:
     "@typescript-eslint/types": "npm:5.62.0"
     eslint-visitor-keys: "npm:^3.3.0"
   checksum: 10/dc613ab7569df9bbe0b2ca677635eb91839dfb2ca2c6fa47870a5da4f160db0b436f7ec0764362e756d4164e9445d49d5eb1ff0b87f4c058946ae9d8c92eb388
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:6.21.0"
+    eslint-visitor-keys: "npm:^3.4.1"
+  checksum: 10/30422cdc1e2ffad203df40351a031254b272f9c6f2b7e02e9bfa39e3fc2c7b1c6130333b0057412968deda17a3a68a578a78929a8139c6acef44d9d841dc72e1
   languageName: node
   linkType: hard
 
@@ -7432,6 +8085,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.48.1"
     eslint-visitor-keys: "npm:^4.2.1"
   checksum: 10/63aa165c57e6b38700adf84da2e90537577cdeb69d05031e3e70785fa412d96d539dc4c1696a0b7bc93284613f8b92fb1bb40f6068bb75347a942120b246ac60
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/visitor-keys@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.59.2"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10/ec8d797272c12b53b9eb2b508c326823b2cb17f6bcf57606238b812bb73854675919a5e772a42499ec1ac7787a16d018fffd94e6b168cc0b58a9872b16d6f1da
   languageName: node
   linkType: hard
 
@@ -7944,12 +8607,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-import-attributes@npm:^1.9.5":
-  version: 1.9.5
-  resolution: "acorn-import-attributes@npm:1.9.5"
-  peerDependencies:
-    acorn: ^8
-  checksum: 10/8bfbfbb6e2467b9b47abb4d095df717ab64fce2525da65eabee073e85e7975fb3a176b6c8bba17c99a7d8ede283a10a590272304eb54a93c4aa1af9790d47a8b
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 10/ea1343992b40b2bfb3a3113fa9c3c2f918ba0f9197ae565c48d3f84d44b174f6b1d5cd9989decd7655963eb03a272abc36968cc439c2907f999bd5ef8653d5a7
   languageName: node
   linkType: hard
 
@@ -8010,6 +8674,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: "npm:^8.0.0"
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 10/5679b9f9ced9d0213a202a37f3aa91efcffe59a6de1a6e3da5c873344d3c161820a1f11cc29899661fee36271fd2895dd3851b6461c902a752ad661d1c1e8722
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
@@ -8063,6 +8741,18 @@ __metadata:
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
   checksum: 10/ee3c62162c953e91986c838f004132b6a253d700f1e51253b99791e2dbfdb39161bc950ebdc2f156f8568035bb5ed8be7bd78289cd9ecbf3381fe8f5b82e3f33
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.17.1":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10/5ce59c0537f4c2aca9a758b412659ec70acb4d5dde971c10ecf21d2e3d799f99acdb4a08e1f5fb2e067c8542930398aae793bb996bb07d3feb81dae22fe2ada9
   languageName: node
   linkType: hard
 
@@ -8411,13 +9101,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-kit@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "ast-kit@npm:2.2.0"
+"ast-kit@npm:^3.0.0-beta.1":
+  version: 3.0.0-beta.1
+  resolution: "ast-kit@npm:3.0.0-beta.1"
   dependencies:
-    "@babel/parser": "npm:^7.28.5"
+    "@babel/parser": "npm:^8.0.0-beta.4"
+    estree-walker: "npm:^3.0.3"
     pathe: "npm:^2.0.3"
-  checksum: 10/82cf2a8c2d5eadce177a62c1461b7374be5269e6d771e67d83f99d89ad5f75a4c3ba1d3bd71c931a2ecca061769240ed7968ddcee581697e7304375135ab2106
+  checksum: 10/63c8f80f71d905a3ca23a2cd02e9e9bba4e617353db80e58e4a48ca31f5a51c594e3d5bf7d1b61faf98b5f4c9a4db52bd2e8fa69e01e5b17a737b10abbd087f9
   languageName: node
   linkType: hard
 
@@ -8741,6 +9432,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10/fb07bb66a0959c2843fc055838047e2a95ccebb837c519614afb067ebfdf2fa967ca8d712c35ced07f2cd26fc6f07964230b094891315ad74f11eba3d53178a0
+  languageName: node
+  linkType: hard
+
 "bare-abort-controller@npm:^1.0.0":
   version: 1.0.0
   resolution: "bare-abort-controller@npm:1.0.0"
@@ -8799,6 +9497,13 @@ __metadata:
   version: 3.4.2
   resolution: "bare-buffer@npm:3.4.2"
   checksum: 10/efe20bb667c893935813c19715f4a3c12e80029f62e7f73997c26f64a452f0d3eae7886f1653158573a2b66596144cf53628c0251febecde135d46132ddbd2f8
+  languageName: node
+  linkType: hard
+
+"bare-buffer@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "bare-buffer@npm:3.6.0"
+  checksum: 10/09d5dcd99232cc9551035f196221893461f2935cf880f53ad0aa98f8eb08f1006ec625794b8f27640f5c53c3c89fbb918a3659bf0272b0914255ba231c9a9eca
   languageName: node
   linkType: hard
 
@@ -8918,33 +9623,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-fetch@npm:^2.4.1, bare-fetch@npm:^2.5.0":
-  version: 2.5.1
-  resolution: "bare-fetch@npm:2.5.1"
+"bare-fetch@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "bare-fetch@npm:3.0.1"
   dependencies:
-    bare-form-data: "npm:^1.1.3"
-    bare-http1: "npm:^4.0.2"
-    bare-https: "npm:^2.0.0"
-    bare-stream: "npm:^2.7.0"
+    bare-form-data: "npm:^1.2.0"
+    bare-http1: "npm:^4.5.2"
+    bare-https: "npm:^3.0.0"
+    bare-mime: "npm:^1.0.0"
+    bare-stream: "npm:^2.9.1"
+    bare-url: "npm:^2.4.0"
     bare-zlib: "npm:^1.3.0"
   peerDependencies:
+    bare-abort-controller: "*"
     bare-buffer: "*"
-    bare-url: "*"
   peerDependenciesMeta:
+    bare-abort-controller:
+      optional: true
     bare-buffer:
       optional: true
-    bare-url:
-      optional: true
-  checksum: 10/657450babb739bd2cc20588d8960b2a1e7257984f779d44e4ec21112227393c9f11f3c8d33732d390b45130463cb9744dc6b4417fd076b42001af488da0cb2f1
+  checksum: 10/c3db003f9d56335a81f9520b2667ab8b2de3e7e4422114c9fd0f4137d9dcfd6e67e3bfde94bd6b876c60de3333c7e2f40c41211d5fb978509660947368f5aee3
   languageName: node
   linkType: hard
 
-"bare-form-data@npm:^1.1.3":
-  version: 1.1.6
-  resolution: "bare-form-data@npm:1.1.6"
+"bare-form-data@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "bare-form-data@npm:1.2.1"
   dependencies:
+    bare-buffer: "npm:^3.6.0"
     bare-stream: "npm:^2.6.5"
-  checksum: 10/3667290c6b3252d406e4f2a5d57d5054fe208a9fe6f2a7ac10208b775ad80a03e38bf2eea5c843f40e44e1821c8f6f2e910e275a7e9d0a5ff9832faaee129f83
+  checksum: 10/b745a5e371f874a95f95e15d05c32964a13f1c52d2776817d32fc972e2719bd9b37b4ddd023a34a5cb5aba30faa8651efa521c9de23485b7111ff5f9b2361e17
   languageName: node
   linkType: hard
 
@@ -8989,7 +9697,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-http1@npm:^4.0.0, bare-http1@npm:^4.0.2, bare-http1@npm:^4.0.4":
+"bare-http-parser@npm:^1.1.1":
+  version: 1.1.3
+  resolution: "bare-http-parser@npm:1.1.3"
+  checksum: 10/184627336688c33f4574b9ed6297f4c36b967c599d093e6de81505b7d1cf0feaecf58edddd2af8c4878e49c0b2b4bdc5f840e5a2fa58cd3843109fee7edb7f73
+  languageName: node
+  linkType: hard
+
+"bare-http1@npm:^4.0.0, bare-http1@npm:^4.0.4":
   version: 4.1.6
   resolution: "bare-http1@npm:4.1.6"
   dependencies:
@@ -9009,14 +9724,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-https@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "bare-https@npm:2.1.1"
+"bare-http1@npm:^4.4.0, bare-http1@npm:^4.5.2":
+  version: 4.5.6
+  resolution: "bare-http1@npm:4.5.6"
   dependencies:
-    bare-http1: "npm:^4.0.0"
+    bare-events: "npm:^2.6.0"
+    bare-http-parser: "npm:^1.1.1"
+    bare-stream: "npm:^2.10.0"
     bare-tcp: "npm:^2.2.0"
-    bare-tls: "npm:^2.0.0"
-  checksum: 10/d736b99d384859f0f1cc2e6c90d022340360c547d349e4177c2298703d6ae61f3e69e7210650f482d65ac56613bb365b766e3f9c99385bf2aa8d250e05c8d756
+  peerDependencies:
+    bare-buffer: "*"
+    bare-url: "*"
+  peerDependenciesMeta:
+    bare-buffer:
+      optional: true
+    bare-url:
+      optional: true
+  checksum: 10/1f88bac0bf94c4f4acbba7bc2632d284d48c911f4340ac953b4a00827938c48ca1d6015ea3f0e8b5a1d5c1a122ab63847d0036e69edaee9aeb01c57c87110544
+  languageName: node
+  linkType: hard
+
+"bare-https@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "bare-https@npm:3.0.0"
+  dependencies:
+    bare-http1: "npm:^4.4.0"
+    bare-tcp: "npm:^2.2.0"
+    bare-tls: "npm:^3.0.0"
+  checksum: 10/7933cfad4266e9523636efe6c4626577863e997e83beddf533ac29ab84630a575674f589369baf0b3dd8a3e1ddac4d66cdd1ec4a8a7ed78fc98306e68abc4460
   languageName: node
   linkType: hard
 
@@ -9030,21 +9765,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-inspector@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "bare-inspector@npm:5.0.0"
+"bare-inspector@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "bare-inspector@npm:6.0.1"
   dependencies:
     bare-events: "npm:^2.1.0"
     bare-http1: "npm:^4.0.0"
     bare-stream: "npm:^2.0.0"
     bare-url: "npm:^2.0.0"
-    bare-ws: "npm:^2.0.0"
+    bare-ws: "npm:^3.0.0"
   peerDependencies:
     bare-tcp: "*"
   peerDependenciesMeta:
     bare-tcp:
       optional: true
-  checksum: 10/a8a98c6db06c2a882164919b9403cb46b74270cbd9142785da25bb3ab45c991e960d7059c111b57bea1a52d17ba0116e7ec00ddb9c1c8b129b8ad08e60556f43
+  checksum: 10/c3cafbf0cca5ac3f1241e633515c350a3d49ecf30a243eb3c172e298b130e8fd725c8f67cae6f6b22586f342e63b5565bd699476c7e2560d929ab0878abf3259
   languageName: node
   linkType: hard
 
@@ -9078,6 +9813,13 @@ __metadata:
   bin:
     bare-make: bin.js
   checksum: 10/5399b3a4d62429e76ef82b98df864b6eaafb1de6737592d0035f85d1a4fa347321dcdb8194f94c707a401b9f6066736b58c80da94e3e125a29d81f4fa76535fb
+  languageName: node
+  linkType: hard
+
+"bare-mime@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "bare-mime@npm:1.0.0"
+  checksum: 10/ed9eb9c86b39f8441a33ebce7ae9f4d720e96c2f641799a64fc494e5b3ea525a9096420470281e94dc38fc5c016bcc391c051c79eb76bb90e909294a8425ab53
   languageName: node
   linkType: hard
 
@@ -9158,9 +9900,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-node-runtime@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "bare-node-runtime@npm:1.1.4"
+"bare-node-runtime@npm:^1.2.0":
+  version: 1.3.1
+  resolution: "bare-node-runtime@npm:1.3.1"
   dependencies:
     bare-abort-controller: "npm:^1.0.0"
     bare-assert: "npm:^1.1.0"
@@ -9172,16 +9914,16 @@ __metadata:
     bare-diagnostics-channel: "npm:^1.1.0"
     bare-dns: "npm:^2.1.4"
     bare-events: "npm:^2.7.0"
-    bare-fetch: "npm:^2.5.0"
+    bare-fetch: "npm:^3.0.0"
     bare-fs: "npm:^4.2.3"
     bare-http1: "npm:^4.0.4"
-    bare-https: "npm:^2.0.0"
-    bare-inspector: "npm:^5.0.0"
+    bare-https: "npm:^3.0.0"
+    bare-inspector: "npm:^6.0.1"
     bare-module: "npm:^6.1.2"
     bare-net: "npm:^2.0.2"
     bare-os: "npm:^3.6.2"
     bare-path: "npm:^3.0.0"
-    bare-performance: "npm:^1.1.0"
+    bare-performance: "npm:^2.0.0"
     bare-process: "npm:^4.2.1"
     bare-punycode: "npm:^0.0.0"
     bare-querystring: "npm:^1.0.0"
@@ -9189,17 +9931,18 @@ __metadata:
     bare-repl: "npm:^6.0.1"
     bare-stream: "npm:^2.7.0"
     bare-string-decoder: "npm:^1.0.0"
-    bare-subprocess: "npm:^5.1.1"
+    bare-subprocess: "npm:^6.0.0"
     bare-timers: "npm:^3.0.3"
-    bare-tls: "npm:^2.1.3"
+    bare-tls: "npm:^3.0.0"
     bare-tty: "npm:^5.0.3"
     bare-url: "npm:^2.2.2"
     bare-utils: "npm:^1.5.1"
     bare-v8: "npm:^1.0.1"
     bare-vm: "npm:^1.0.0"
     bare-worker: "npm:^4.0.0"
+    bare-ws: "npm:^3.0.0"
     bare-zlib: "npm:^1.3.1"
-  checksum: 10/ae9afa6ee8103d58595b3b03807c4a1ced8cfc1b2d279699d6cc0ab6071c3678113857ce781a4320fa3db676c920b4924554504d9c09ab57e3c48c5b774f62cf
+  checksum: 10/71c3255341c0bb52330eba7bd73367e75280a01331cf3721010d20e6596bd41420ddd099a492c7cc30c2127e1835d3d337f559645a8f95621d2656b66fa7ce94
   languageName: node
   linkType: hard
 
@@ -9219,10 +9962,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-performance@npm:^1.1.0":
-  version: 1.2.1
-  resolution: "bare-performance@npm:1.2.1"
-  checksum: 10/6d6e5becbc54cb302cdf04956d3ab70343d5788407adc0a39c34a5ae2bfede4c532034ae52e11ce56c3faf1e4cca19e1d8d7709260e456b35a5fcc70af54d772
+"bare-performance@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "bare-performance@npm:2.0.0"
+  checksum: 10/84d52d36be8954e022b37cf8e53b17e9c09a6fb56500481bf8743c5c40ad4da32fe6cf0fe19ae50af20f1a2a1c6f3d95d2ab8ebc43f615ca94f169e62c9ead98
   languageName: node
   linkType: hard
 
@@ -9300,9 +10043,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-android-arm64@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-android-arm64@npm:1.24.2"
+"bare-runtime-android-arm64@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-android-arm64@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9311,9 +10054,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-android-arm@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-android-arm@npm:1.24.2"
+"bare-runtime-android-arm@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-android-arm@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9322,9 +10065,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-android-ia32@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-android-ia32@npm:1.24.2"
+"bare-runtime-android-ia32@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-android-ia32@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9333,9 +10076,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-android-x64@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-android-x64@npm:1.24.2"
+"bare-runtime-android-x64@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-android-x64@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9344,9 +10087,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-darwin-arm64@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-darwin-arm64@npm:1.24.2"
+"bare-runtime-darwin-arm64@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-darwin-arm64@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9355,9 +10098,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-darwin-x64@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-darwin-x64@npm:1.24.2"
+"bare-runtime-darwin-x64@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-darwin-x64@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9366,9 +10109,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-ios-arm64-simulator@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-ios-arm64-simulator@npm:1.24.2"
+"bare-runtime-ios-arm64-simulator@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-ios-arm64-simulator@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9377,9 +10120,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-ios-arm64@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-ios-arm64@npm:1.24.2"
+"bare-runtime-ios-arm64@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-ios-arm64@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9388,9 +10131,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-ios-x64-simulator@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-ios-x64-simulator@npm:1.24.2"
+"bare-runtime-ios-x64-simulator@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-ios-x64-simulator@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9399,9 +10142,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-linux-arm64@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-linux-arm64@npm:1.24.2"
+"bare-runtime-linux-arm64@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-linux-arm64@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9410,9 +10153,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-linux-x64@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-linux-x64@npm:1.24.2"
+"bare-runtime-linux-x64@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-linux-x64@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9421,9 +10164,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-win32-arm64@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-win32-arm64@npm:1.24.2"
+"bare-runtime-win32-arm64@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-win32-arm64@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9432,9 +10175,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime-win32-x64@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime-win32-x64@npm:1.24.2"
+"bare-runtime-win32-x64@npm:1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime-win32-x64@npm:1.28.4"
   dependencies:
     require-asset: "npm:^1.0.2"
   bin:
@@ -9443,27 +10186,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-runtime@npm:1.24.2":
-  version: 1.24.2
-  resolution: "bare-runtime@npm:1.24.2"
+"bare-runtime@npm:^1.28.4":
+  version: 1.28.4
+  resolution: "bare-runtime@npm:1.28.4"
   dependencies:
     bare-fs: "npm:^4.4.4"
     bare-os: "npm:^3.0.1"
     bare-path: "npm:^3.0.0"
     bare-process: "npm:^4.2.1"
-    bare-runtime-android-arm: "npm:1.24.2"
-    bare-runtime-android-arm64: "npm:1.24.2"
-    bare-runtime-android-ia32: "npm:1.24.2"
-    bare-runtime-android-x64: "npm:1.24.2"
-    bare-runtime-darwin-arm64: "npm:1.24.2"
-    bare-runtime-darwin-x64: "npm:1.24.2"
-    bare-runtime-ios-arm64: "npm:1.24.2"
-    bare-runtime-ios-arm64-simulator: "npm:1.24.2"
-    bare-runtime-ios-x64-simulator: "npm:1.24.2"
-    bare-runtime-linux-arm64: "npm:1.24.2"
-    bare-runtime-linux-x64: "npm:1.24.2"
-    bare-runtime-win32-arm64: "npm:1.24.2"
-    bare-runtime-win32-x64: "npm:1.24.2"
+    bare-runtime-android-arm: "npm:1.28.4"
+    bare-runtime-android-arm64: "npm:1.28.4"
+    bare-runtime-android-ia32: "npm:1.28.4"
+    bare-runtime-android-x64: "npm:1.28.4"
+    bare-runtime-darwin-arm64: "npm:1.28.4"
+    bare-runtime-darwin-x64: "npm:1.28.4"
+    bare-runtime-ios-arm64: "npm:1.28.4"
+    bare-runtime-ios-arm64-simulator: "npm:1.28.4"
+    bare-runtime-ios-x64-simulator: "npm:1.28.4"
+    bare-runtime-linux-arm64: "npm:1.28.4"
+    bare-runtime-linux-x64: "npm:1.28.4"
+    bare-runtime-win32-arm64: "npm:1.28.4"
+    bare-runtime-win32-x64: "npm:1.28.4"
     bare-subprocess: "npm:^5.0.0"
   dependenciesMeta:
     bare-runtime-android-arm:
@@ -9494,7 +10237,7 @@ __metadata:
       optional: true
   bin:
     bare: bin/bare
-  checksum: 10/3d88094a61b9e6db664db306fd8bd7c756a0f2be60fd246b3e225d47bb9deb774a9a26a922a0694a73581640767317dc80aede22596c55d92ed08d79d97298ec
+  checksum: 10/262929afce47b684e9f727b52d98ad68b0a3a2ab65b80276ef8fbf89b84ca93a515506a2224011253484a2915ebf8283ec49bc654611b2fb0431d83408d077b3
   languageName: node
   linkType: hard
 
@@ -9532,6 +10275,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bare-stream@npm:^2.10.0, bare-stream@npm:^2.9.1":
+  version: 2.13.1
+  resolution: "bare-stream@npm:2.13.1"
+  dependencies:
+    streamx: "npm:^2.25.0"
+    teex: "npm:^1.0.1"
+  peerDependencies:
+    bare-abort-controller: "*"
+    bare-buffer: "*"
+    bare-events: "*"
+  peerDependenciesMeta:
+    bare-abort-controller:
+      optional: true
+    bare-buffer:
+      optional: true
+    bare-events:
+      optional: true
+  checksum: 10/50aa90a7005d71c1af8fafcc84f378bd4d7c2dd293a581ffe3899bee39b0d2eb07c47e1092f581fa5b199a63c0ad2618b150c0ab716658727e3fcc7fd7d1e401
+  languageName: node
+  linkType: hard
+
 "bare-string-decoder@npm:^1.0.0":
   version: 1.0.0
   resolution: "bare-string-decoder@npm:1.0.0"
@@ -9564,7 +10328,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-subprocess@npm:^5.0.0, bare-subprocess@npm:^5.1.1":
+"bare-subprocess@npm:^5.0.0":
   version: 5.2.1
   resolution: "bare-subprocess@npm:5.2.1"
   dependencies:
@@ -9579,6 +10343,24 @@ __metadata:
     bare-buffer:
       optional: true
   checksum: 10/8c67a36138d0476ea292a3e4a008cf242ce19126d2451739ea6add2760794ff03b3423d999d066fd81201690f8a48e1e0c7ebfdb71314e9030f329588372be18
+  languageName: node
+  linkType: hard
+
+"bare-subprocess@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "bare-subprocess@npm:6.0.0"
+  dependencies:
+    bare-env: "npm:^3.0.0"
+    bare-events: "npm:^2.5.4"
+    bare-os: "npm:^3.0.1"
+    bare-pipe: "npm:^4.0.0"
+    bare-url: "npm:^2.2.2"
+  peerDependencies:
+    bare-buffer: "*"
+  peerDependenciesMeta:
+    bare-buffer:
+      optional: true
+  checksum: 10/df7daa13574a51af41f7d1ee0771443298c49a6803c46480df964bf772b58696afb3ff33d3cdcb867794eb53963b17e07cc1c396f619f8ed0063036c4b711849
   languageName: node
   linkType: hard
 
@@ -9616,13 +10398,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-tls@npm:^2.0.0, bare-tls@npm:^2.1.3":
-  version: 2.1.5
-  resolution: "bare-tls@npm:2.1.5"
+"bare-tls@npm:^3.0.0":
+  version: 3.1.3
+  resolution: "bare-tls@npm:3.1.3"
   dependencies:
     bare-net: "npm:^2.0.1"
     bare-stream: "npm:^2.6.4"
-  checksum: 10/0680f21b33d7ee6b010fa04269d22bccd284976d250c53e8bc31d3ea1196ad11cda3b7de45743d0358164d8a901177618c97b772b4e725157fa0b0e3fc4e3f32
+  checksum: 10/30c8dd2e0ef77bde3971d5e324c11d0c097cdb6ee2614ae973291a19bb1e534bb4d03f43bb2376384b182653282bcfe7bc0bf77e55f7e1c582bc7d1660f2411c
   languageName: node
   linkType: hard
 
@@ -9650,6 +10432,15 @@ __metadata:
   dependencies:
     bare-path: "npm:^3.0.0"
   checksum: 10/aa203d79e2dafdb47a4e3bee398cb7db5c7eabcf0b3adf1e1530a21ac69806d1ca05b3343666e3aeda9fc3568c995272deea8ae3cead77ad00f66a7e415de0ef
+  languageName: node
+  linkType: hard
+
+"bare-url@npm:^2.4.0":
+  version: 2.4.3
+  resolution: "bare-url@npm:2.4.3"
+  dependencies:
+    bare-path: "npm:^3.0.0"
+  checksum: 10/e2c16dd57e0c4b974813d9acd626b96e83a8894e19b0bf780de4bef40a7000c697984a47c398c8f612aa7991974bfb97f1c3c3fd410085a55fa5db15d1ba6309
   languageName: node
   linkType: hard
 
@@ -9694,14 +10485,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-ws@npm:^2.0.0":
-  version: 2.0.4
-  resolution: "bare-ws@npm:2.0.4"
+"bare-ws@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "bare-ws@npm:3.0.0"
   dependencies:
     bare-crypto: "npm:^1.2.0"
     bare-events: "npm:^2.3.1"
     bare-http1: "npm:^4.0.0"
-    bare-https: "npm:^2.0.0"
+    bare-https: "npm:^3.0.0"
     bare-stream: "npm:^2.1.2"
   peerDependencies:
     bare-buffer: "*"
@@ -9711,7 +10502,7 @@ __metadata:
       optional: true
     bare-url:
       optional: true
-  checksum: 10/99ca6d4f232c08d9c4107022158eb22c6324f34bc8946e63c44d8c696399e75d3c995831fcf6fc2522cc084c88867a0aeeca09ade7141d80974ebde946babdf9
+  checksum: 10/ac9b215e3d757d269c095a67dc71582e45dab6d6b49a2f2efe0a2dc8d7ddd8a8b8130631beaae3395540e2001adce9789a1b135a3d5a956899c4711181916da5
   languageName: node
   linkType: hard
 
@@ -9724,16 +10515,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare@npm:^1.23.3":
-  version: 1.24.2
-  resolution: "bare@npm:1.24.2"
-  dependencies:
-    bare-runtime: "npm:1.24.2"
+"bare@npm:^1.28.4":
+  version: 1.28.4
+  resolution: "bare@npm:1.28.4"
   peerDependencies:
     bare-buffer: "*"
     bare-console: "*"
     bare-events: "*"
     bare-queue-microtask: "*"
+    bare-runtime: "*"
     bare-structured-clone: "*"
     bare-timers: "*"
     bare-url: "*"
@@ -9754,7 +10544,7 @@ __metadata:
       optional: true
   bin:
     bare: bin/bare
-  checksum: 10/9eab8473bc2ea8a4ac35e4f55bb835b2dd5024699640c261e5f130ed6f89d24b19eba14fb4256c865a2c3a9fe5c2ad5f746884778600eec7431e974f05278169
+  checksum: 10/e07cbc0f9e1f5c1776beba8e092674c957e9f7dfceb23206f293eeb818637481585ba174811d3d1b7ec243bc1276e8aceaa26249a90a05017ac3adb3c57aa736
   languageName: node
   linkType: hard
 
@@ -9889,13 +10679,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.11.9":
-  version: 4.12.2
-  resolution: "bn.js@npm:4.12.2"
-  checksum: 10/5803983405c087443e0e6c9bb5d0bc863d9f987d77e710f81b14c55616494f5a274e1650ee892531acb3529d52c0e0ea48aa12d2873dd80a75dde9d73a2ec518
-  languageName: node
-  linkType: hard
-
 "body-parser@npm:1.20.3":
   version: 1.20.3
   resolution: "body-parser@npm:1.20.3"
@@ -9933,6 +10716,23 @@ __metadata:
     type-is: "npm:~1.6.18"
     unpipe: "npm:~1.0.0"
   checksum: 10/ff67e28d3f426707be8697a75fdf8d564dc50c341b41f054264d8ab6e2924e519c7ce8acc9d0de05328fdc41e1d9f3f200aec9c1cfb1867d6b676a410d97c689
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:^2.2.1":
+  version: 2.2.2
+  resolution: "body-parser@npm:2.2.2"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^1.0.5"
+    debug: "npm:^4.4.3"
+    http-errors: "npm:^2.0.0"
+    iconv-lite: "npm:^0.7.0"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.14.1"
+    raw-body: "npm:^3.0.1"
+    type-is: "npm:^2.0.1"
+  checksum: 10/69671f67d4d5ae5974593901a92d639757231da1725ed6de4d35e86cde9ce7650afdf1cd28df9b6f7892ea7f9eb03ccb30c70fe27d679275ae4cb4aae5ce1b21
   languageName: node
   linkType: hard
 
@@ -10006,19 +10806,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "brace-expansion@npm:5.0.5"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
+  languageName: node
+  linkType: hard
+
 "braces@npm:^3.0.3, braces@npm:~3.0.2":
   version: 3.0.3
   resolution: "braces@npm:3.0.3"
   dependencies:
     fill-range: "npm:^7.1.1"
   checksum: 10/fad11a0d4697a27162840b02b1fad249c1683cbc510cd5bf1a471f2f8085c046d41094308c577a50a03a579dd99d5a6b3724c4b5e8b14df2c4443844cfcda2c6
-  languageName: node
-  linkType: hard
-
-"brorand@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "brorand@npm:1.1.0"
-  checksum: 10/8a05c9f3c4b46572dec6ef71012b1946db6cae8c7bb60ccd4b7dd5a84655db49fe043ecc6272e7ef1f69dc53d6730b9e2a3a03a8310509a3d797a618cbee52be
   languageName: node
   linkType: hard
 
@@ -10227,7 +11029,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.1.2, bytes@npm:~3.1.2":
+"bytes@npm:3.1.2, bytes@npm:^3.1.2, bytes@npm:~3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10/a10abf2ba70c784471d6b4f58778c0beeb2b5d405148e66affa91f23a9f13d07603d0a0354667310ae1d6dc141474ffd44e2a074be0f6e2254edb8fc21445388
@@ -10511,7 +11313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cjs-module-lexer@npm:^1.0.0, cjs-module-lexer@npm:^1.2.2, cjs-module-lexer@npm:^1.2.3":
+"cjs-module-lexer@npm:^1.0.0, cjs-module-lexer@npm:^1.2.3":
   version: 1.4.3
   resolution: "cjs-module-lexer@npm:1.4.3"
   checksum: 10/d2b92f919a2dedbfd61d016964fce8da0035f827182ed6839c97cac56e8a8077cfa6a59388adfe2bc588a19cef9bbe830d683a76a6e93c51f65852062cfe2591
@@ -10703,6 +11505,13 @@ __metadata:
   version: 0.0.5
   resolution: "cmake-cargo@npm:0.0.5"
   checksum: 10/3ea8f7e4b30cf0e2457f5cac1299461c4dbf7ea1b7d28da4df0fc5e2641936ad18d313caecd96d47371e98f7641181e1df734aa65b36e44b3e72d443470c3ada
+  languageName: node
+  linkType: hard
+
+"cmake-fetch@npm:^1.4.7":
+  version: 1.5.1
+  resolution: "cmake-fetch@npm:1.5.1"
+  checksum: 10/c9df3fb441181dfe6944fb3b534a19e291c749844efc369862af1c1359e0571d61dd83bddfe96d4371ffe001c1785e1a01081688e763835ed008b959c984e024
   languageName: node
   linkType: hard
 
@@ -11118,6 +11927,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"confusing-browser-globals@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "confusing-browser-globals@npm:1.0.11"
+  checksum: 10/3afc635abd37e566477f610e7978b15753f0e84025c25d49236f1f14d480117185516bdd40d2a2167e6bed8048641a9854964b9c067e3dcdfa6b5d0ad3c3a5ef
+  languageName: node
+  linkType: hard
+
 "connect-history-api-fallback@npm:^2.0.0":
   version: 2.0.0
   resolution: "connect-history-api-fallback@npm:2.0.0"
@@ -11153,7 +11969,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:~1.0.4, content-type@npm:~1.0.5":
+"content-disposition@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "content-disposition@npm:1.1.0"
+  checksum: 10/c4f65e3c001a4a8eb87d0d24c0f112abb139836fb13b8ea67276715e7dce09570ef666ba7848ee8b660d467e6588d030c8ed7e8d0128db6ca78a0800dcd8c7a8
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^1.0.5, content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 10/585847d98dc7fb8035c02ae2cb76c7a9bd7b25f84c447e5ed55c45c2175e83617c8813871b4ee22f368126af6b2b167df655829007b21aa10302873ea9c62662
@@ -11181,6 +12004,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-signature@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "cookie-signature@npm:1.2.2"
+  checksum: 10/be44a3c9a56f3771aea3a8bd8ad8f0a8e2679bcb967478267f41a510b4eb5ec55085386ba79c706c4ac21605ca76f4251973444b90283e0eb3eeafe8a92c7708
+  languageName: node
+  linkType: hard
+
 "cookie-signature@npm:~1.0.6":
   version: 1.0.7
   resolution: "cookie-signature@npm:1.0.7"
@@ -11195,7 +12025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:~0.7.1":
+"cookie@npm:^0.7.1, cookie@npm:~0.7.1":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10/24b286c556420d4ba4e9bc09120c9d3db7d28ace2bd0f8ccee82422ce42322f73c8312441271e5eefafbead725980e5996cc02766dbb89a90ac7f5636ede608f
@@ -11232,6 +12062,16 @@ __metadata:
     object-assign: "npm:^4"
     vary: "npm:^1"
   checksum: 10/66e88e08edee7cbce9d92b4d28a2028c88772a4c73e02f143ed8ca76789f9b59444eed6b1c167139e76fa662998c151322720093ba229f9941365ada5a6fc2c6
+  languageName: node
+  linkType: hard
+
+"cors@npm:^2.8.5":
+  version: 2.8.6
+  resolution: "cors@npm:2.8.6"
+  dependencies:
+    object-assign: "npm:^4"
+    vary: "npm:^1"
+  checksum: 10/aa7174305b21ceb90f9c84f4eaa32f04432d333addbfdc0d1eb7310393c48902e5364aada5ac2f5d054528d63b3179238444475426fcb74e1e345077de485727
   languageName: node
   linkType: hard
 
@@ -11502,7 +12342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.1":
+"debug@npm:4, debug@npm:^4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -11686,7 +12526,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:2.0.0, depd@npm:~2.0.0":
+"depd@npm:2.0.0, depd@npm:^2.0.0, depd@npm:~2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10/c0c8ff36079ce5ada64f46cc9d6fd47ebcf38241105b6e0c98f412e8ad91f084bcf906ff644cc3a4bd876ca27a62accb8b0fff72ea6ed1a414b89d8506f4a5ca
@@ -12161,21 +13001,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.5.7":
-  version: 6.6.1
-  resolution: "elliptic@npm:6.6.1"
-  dependencies:
-    bn.js: "npm:^4.11.9"
-    brorand: "npm:^1.1.0"
-    hash.js: "npm:^1.0.0"
-    hmac-drbg: "npm:^1.0.1"
-    inherits: "npm:^2.0.4"
-    minimalistic-assert: "npm:^1.0.1"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10/dc678c9febd89a219c4008ba3a9abb82237be853d9fd171cd602c8fb5ec39927e65c6b5e7a1b2a4ea82ee8e0ded72275e7932bb2da04a5790c2638b818e4e1c5
-  languageName: node
-  linkType: hard
-
 "emittery@npm:^0.13.1":
   version: 0.13.1
   resolution: "emittery@npm:0.13.1"
@@ -12225,17 +13050,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encodeurl@npm:^2.0.0, encodeurl@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "encodeurl@npm:2.0.0"
+  checksum: 10/abf5cd51b78082cf8af7be6785813c33b6df2068ce5191a40ca8b1afe6a86f9230af9a9ce694a5ce4665955e5c1120871826df9c128a642e09c58d592e2807fe
+  languageName: node
+  linkType: hard
+
 "encodeurl@npm:~1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
   checksum: 10/e50e3d508cdd9c4565ba72d2012e65038e5d71bdc9198cb125beb6237b5b1ade6c0d343998da9e170fb2eae52c1bed37d4d6d98a46ea423a0cddbed5ac3f780c
-  languageName: node
-  linkType: hard
-
-"encodeurl@npm:~2.0.0":
-  version: 2.0.0
-  resolution: "encodeurl@npm:2.0.0"
-  checksum: 10/abf5cd51b78082cf8af7be6785813c33b6df2068ce5191a40ca8b1afe6a86f9230af9a9ce694a5ce4665955e5c1120871826df9c128a642e09c58d592e2807fe
   languageName: node
   linkType: hard
 
@@ -12692,7 +13517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-html@npm:~1.0.3":
+"escape-html@npm:^1.0.3, escape-html@npm:~1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 10/6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
@@ -12849,6 +13674,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-comment-length@npm:^1.7.2":
+  version: 1.7.3
+  resolution: "eslint-plugin-comment-length@npm:1.7.3"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^6.10.0"
+  peerDependencies:
+    eslint: ">=8.0.0"
+  checksum: 10/f6635e1cba89ff7f9e75c4f8c60e58929a3125b23eb8e9a5e965537e6598d583fc65415d359c54695a01e5eb077e6532867380e7007c9ca7b65534af82b27aae
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-eslint-comments@npm:^3.2.0":
   version: 3.2.0
   resolution: "eslint-plugin-eslint-comments@npm:3.2.0"
@@ -12887,7 +13723,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.30.0, eslint-plugin-import@npm:^2.31.0":
+"eslint-plugin-import@npm:^2.29.0, eslint-plugin-import@npm:^2.30.0, eslint-plugin-import@npm:^2.31.0":
   version: 2.32.0
   resolution: "eslint-plugin-import@npm:2.32.0"
   dependencies:
@@ -12934,7 +13770,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsx-a11y@npm:^6.10.0":
+"eslint-plugin-jest@npm:^29.15.0":
+  version: 29.15.2
+  resolution: "eslint-plugin-jest@npm:29.15.2"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^8.0.0"
+  peerDependencies:
+    "@typescript-eslint/eslint-plugin": ^8.0.0
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    jest: "*"
+    typescript: ">=4.8.4 <7.0.0"
+  peerDependenciesMeta:
+    "@typescript-eslint/eslint-plugin":
+      optional: true
+    jest:
+      optional: true
+    typescript:
+      optional: true
+  checksum: 10/c7bc4dc705e5613e51a1d19bb924a439db9897c67e694f091e29dbacaa218b758040aacbb8d3f9136f2af0171ad69c1c49736b5e3f30098bdf44d4c1e93c6381
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-jsx-a11y@npm:^6.10.0, eslint-plugin-jsx-a11y@npm:^6.8.0":
   version: 6.10.2
   resolution: "eslint-plugin-jsx-a11y@npm:6.10.2"
   dependencies:
@@ -13006,7 +13863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react@npm:^7.30.1, eslint-plugin-react@npm:^7.37.0, eslint-plugin-react@npm:^7.37.3":
+"eslint-plugin-react@npm:^7.30.1, eslint-plugin-react@npm:^7.34.0, eslint-plugin-react@npm:^7.37.0, eslint-plugin-react@npm:^7.37.3":
   version: 7.37.5
   resolution: "eslint-plugin-react@npm:7.37.5"
   dependencies:
@@ -13031,6 +13888,17 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
   checksum: 10/ee1bd4e0ec64f29109d5a625bb703d179c82e0159c86c3f1b52fc1209d2994625a137dae303c333fb308a2e38315e44066d5204998177e31974382f9fda25d5c
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-testing-library@npm:^6.0.2":
+  version: 6.5.0
+  resolution: "eslint-plugin-testing-library@npm:6.5.0"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^5.62.0"
+  peerDependencies:
+    eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
+  checksum: 10/5ce5f71aed5dc39315f7fa2e987c7e1ffc78f7d35164c2d8769ad29000558828dc13c04bfef289c28faf57749ce7720e5ab17869780b743bc1d8cd59a5052a43
   languageName: node
   linkType: hard
 
@@ -13061,7 +13929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.3":
+"eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
   checksum: 10/3f357c554a9ea794b094a09bd4187e5eacd1bc0d0653c3adeb87962c548e6a1ab8f982b86963ae1337f5d976004146536dcee5d0e2806665b193fbfbf1a9231b
@@ -13072,6 +13940,35 @@ __metadata:
   version: 4.2.1
   resolution: "eslint-visitor-keys@npm:4.2.1"
   checksum: 10/3ee00fc6a7002d4b0ffd9dc99e13a6a7882c557329e6c25ab254220d71e5c9c4f89dca4695352949ea678eb1f3ba912a18ef8aac0a7fe094196fd92f441bfce2
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "eslint-visitor-keys@npm:5.0.1"
+  checksum: 10/f9cc1a57b75e0ef949545cac33d01e8367e302de4c1483266ed4d8646ee5c306376660196bbb38b004e767b7043d1e661cb4336b49eff634a1bbe75c1db709ec
+  languageName: node
+  linkType: hard
+
+"eslint-watch@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "eslint-watch@npm:8.0.0"
+  dependencies:
+    chokidar: "npm:^3.5.2"
+    debug: "npm:^4.3.2"
+    execa: "npm:^5.1.1"
+    keypress: "npm:^0.2.1"
+    lodash.debounce: "npm:^4.0.8"
+    lodash.isempty: "npm:^4.4.0"
+    lodash.isequal: "npm:^4.5.0"
+    lodash.kebabcase: "npm:^4.1.1"
+    lodash.unionwith: "npm:^4.6.0"
+    optionator: "npm:^0.9.1"
+  peerDependencies:
+    eslint: ">=8 <9.0.0"
+  bin:
+    esw: bin/esw
+  checksum: 10/eb712ae6692bc3d67609afee5de9ec1cf3d52039b1061f062f2f65741f4a18332b921bfa24fd64772416d93d5ed8f2bfce5e2161e2d817b80b119324ffa643de
   languageName: node
   linkType: hard
 
@@ -13184,6 +14081,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10/a65728d5727b71de172c5df323385755a16c0fdab8234dc756c3854cfee343261ddfbb72a809a5660fac8c75d960bb3e21aa898c2d7e9b19bb298482ca58a3af
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -13191,7 +14097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:~1.8.1":
+"etag@npm:^1.8.1, etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 10/571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
@@ -13239,6 +14145,22 @@ __metadata:
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: 10/a3d47e285e28d324d7180f1e493961a2bbb4cad6412090e4dec114f4db1f5b560c7696ee8e758f55e23913ede856e3689cd3aa9ae13c56b5d8314cd3b3ddd1be
+  languageName: node
+  linkType: hard
+
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1":
+  version: 3.0.8
+  resolution: "eventsource-parser@npm:3.0.8"
+  checksum: 10/286a84a7005e3e669e94dce0bb48f00acfda0d3973671ae2790e48a93f7b27a85b1828df8f3876c70afe4d577b6a7e4f8794cb596072585b584b4f207bc35c15
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "eventsource@npm:3.0.7"
+  dependencies:
+    eventsource-parser: "npm:^3.0.1"
+  checksum: 10/e034915bc97068d1d38617951afd798e6776d6a3a78e36a7569c235b177c7afc2625c9fe82656f7341ab72c7eeecb3fd507b7f88e9328f2448872ff9c4742bb6
   languageName: node
   linkType: hard
 
@@ -13584,6 +14506,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^8.2.1":
+  version: 8.5.0
+  resolution: "express-rate-limit@npm:8.5.0"
+  dependencies:
+    ip-address: "npm:10.1.0"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10/e6905dcc8ac8eb0e094fc72f672ff99beb07210f6da9e8e48942dc8123161f4c220e7066b7a09b7bd8218d0f1c2cd8d2675cdf8e661701cb0ed000a58dc3c3f5
+  languageName: node
+  linkType: hard
+
 "express@npm:4.21.2":
   version: 4.21.2
   resolution: "express@npm:4.21.2"
@@ -13659,6 +14592,42 @@ __metadata:
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
   checksum: 10/f33c1bd0c7d36e2a1f18de9cdc176469d32f68e20258d2941b8d296ab9a4fd9011872c246391bf87714f009fac5114c832ec5ac65cbee39421f1258801eb8470
+  languageName: node
+  linkType: hard
+
+"express@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "express@npm:5.2.1"
+  dependencies:
+    accepts: "npm:^2.0.0"
+    body-parser: "npm:^2.2.1"
+    content-disposition: "npm:^1.0.0"
+    content-type: "npm:^1.0.5"
+    cookie: "npm:^0.7.1"
+    cookie-signature: "npm:^1.2.1"
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    finalhandler: "npm:^2.1.0"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    merge-descriptors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.0"
+    on-finished: "npm:^2.4.1"
+    once: "npm:^1.4.0"
+    parseurl: "npm:^1.3.3"
+    proxy-addr: "npm:^2.0.7"
+    qs: "npm:^6.14.0"
+    range-parser: "npm:^1.2.1"
+    router: "npm:^2.2.0"
+    send: "npm:^1.1.0"
+    serve-static: "npm:^2.2.0"
+    statuses: "npm:^2.0.1"
+    type-is: "npm:^2.0.1"
+    vary: "npm:^1.1.2"
+  checksum: 10/4aa545d89702ac83f645c77abda1b57bcabe288f0b380fb5580fac4e323ea0eb533005c8e666b4e19152fb16d4abf11ba87b22aa9a10857a0485cd86b94639bd
   languageName: node
   linkType: hard
 
@@ -13969,6 +14938,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"finalhandler@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "finalhandler@npm:2.1.1"
+  dependencies:
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    on-finished: "npm:^2.4.1"
+    parseurl: "npm:^1.3.3"
+    statuses: "npm:^2.0.1"
+  checksum: 10/f4ba75c23408d8f9d393c3e875b9452e84d68c925411a6e67b7efa678b0bed5075ef33def4bb65ed8e0dd37c92a3ea354bcbde07303cd4dc2550e12b95885067
+  languageName: node
+  linkType: hard
+
 "finalhandler@npm:~1.3.1":
   version: 1.3.2
   resolution: "finalhandler@npm:1.3.2"
@@ -14166,6 +15149,13 @@ __metadata:
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10/64c88e489b5d08e2f29664eb3c79c705ff9a8eb15d3e597198ef76546d4ade295897a44abb0abd2700e7ef784b2e3cbf1161e4fbf16f59129193fd1030d16da1
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 10/44e1468488363074641991c1340d2a10c5a6f6d7c353d89fd161c49d120c58ebf9890720f7584f509058385836e3ce50ddb60e9f017315a4ba8c6c3461813bfc
   languageName: node
   linkType: hard
 
@@ -14398,12 +15388,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.10.0, get-tsconfig@npm:^4.13.0, get-tsconfig@npm:^4.7.5":
+"get-tsconfig@npm:^4.10.0, get-tsconfig@npm:^4.7.5":
   version: 4.13.0
   resolution: "get-tsconfig@npm:4.13.0"
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
   checksum: 10/3603c6da30e312636e4c20461e779114c9126601d1eca70ee4e36e3e3c00e3c21892d2d920027333afa2cc9e20998a436b14abe03a53cde40742581cb0e9ceb2
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.13.6":
+  version: 4.14.0
+  resolution: "get-tsconfig@npm:4.14.0"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10/f5626971905ca386c9ddeb302504e8a2301b9c05641803267223ebd50b7c81aaf9324d29cf9f4e4ff3f245632c3392aa83719dc6cb3e98b4e4a1702a27c5cc5d
   languageName: node
   linkType: hard
 
@@ -14562,7 +15561,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^15.15.0":
+"globals@npm:^15.0.0, globals@npm:^15.15.0":
   version: 15.15.0
   resolution: "globals@npm:15.15.0"
   checksum: 10/7f561c87b2fd381b27fc2db7df8a4ea7a9bb378667b8a7193e61fd2ca3a876479174e2a303a74345fbea6e1242e16db48915c1fd3bf35adcf4060a795b425e18
@@ -14754,16 +15753,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
-  version: 1.1.7
-  resolution: "hash.js@npm:1.1.7"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    minimalistic-assert: "npm:^1.0.1"
-  checksum: 10/0c89ee4006606a40f92df5cc3c263342e7fea68110f3e9ef032bd2083650430505db01b6b7926953489517d4027535e4fdc7f970412893d3031c361d3ec8f4b3
-  languageName: node
-  linkType: hard
-
 "hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
@@ -14837,17 +15826,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hmac-drbg@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "hmac-drbg@npm:1.0.1"
-  dependencies:
-    hash.js: "npm:^1.0.3"
-    minimalistic-assert: "npm:^1.0.0"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10/0298a1445b8029a69b713d918ecaa84a1d9f614f5857e0c6e1ca517abfa1357216987b2ee08cc6cc73ba82a6c6ddf2ff11b9717a653530ef03be599d4699b836
-  languageName: node
-  linkType: hard
-
 "hoist-non-react-statics@npm:^3.3.0":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
@@ -14863,6 +15841,13 @@ __metadata:
   dependencies:
     parse-passwd: "npm:^1.0.0"
   checksum: 10/18dd4db87052c6a2179d1813adea0c4bfcfa4f9996f0e226fefb29eb3d548e564350fa28ec46b0bf1fbc0a1d2d6922ceceb80093115ea45ff8842a4990139250
+  languageName: node
+  linkType: hard
+
+"hono@npm:^4.11.4":
+  version: 4.12.17
+  resolution: "hono@npm:4.12.17"
+  checksum: 10/5ddbe390cc5f30cd4e0e3ac50d4896fbfa5fa275218345512508cc9061da0a8b504fe6fd81d200cab20e228f5622d0096348460b68ebcf1b47a28ec3501c9d83
   languageName: node
   linkType: hard
 
@@ -14978,19 +15963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:~1.6.2":
-  version: 1.6.3
-  resolution: "http-errors@npm:1.6.3"
-  dependencies:
-    depd: "npm:~1.1.2"
-    inherits: "npm:2.0.3"
-    setprototypeof: "npm:1.1.0"
-    statuses: "npm:>= 1.4.0 < 2"
-  checksum: 10/e48732657ea0b4a09853d2696a584fa59fa2a8c1ba692af7af3137b5491a997d7f9723f824e7e08eb6a87098532c09ce066966ddf0f9f3dd30905e52301acadb
-  languageName: node
-  linkType: hard
-
-"http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
+"http-errors@npm:^2.0.0, http-errors@npm:^2.0.1, http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
   version: 2.0.1
   resolution: "http-errors@npm:2.0.1"
   dependencies:
@@ -15000,6 +15973,18 @@ __metadata:
     statuses: "npm:~2.0.2"
     toidentifier: "npm:~1.0.1"
   checksum: 10/9fe31bc0edf36566c87048aed1d3d0cbe03552564adc3541626a0613f542d753fbcb13bdfcec0a3a530dbe1714bb566c89d46244616b66bddd26ac413b06a207
+  languageName: node
+  linkType: hard
+
+"http-errors@npm:~1.6.2":
+  version: 1.6.3
+  resolution: "http-errors@npm:1.6.3"
+  dependencies:
+    depd: "npm:~1.1.2"
+    inherits: "npm:2.0.3"
+    setprototypeof: "npm:1.1.0"
+    statuses: "npm:>= 1.4.0 < 2"
+  checksum: 10/e48732657ea0b4a09853d2696a584fa59fa2a8c1ba692af7af3137b5491a997d7f9723f824e7e08eb6a87098532c09ce066966ddf0f9f3dd30905e52301acadb
   languageName: node
   linkType: hard
 
@@ -15116,6 +16101,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:~0.7.0":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10/24c937b532f868e938386b62410b303b7c767ce3d08dc2829cbe59464d5a26ef86ae5ad1af6b34eec43ddfea39e7d101638644b0178d67262fa87015d59f983a
+  languageName: node
+  linkType: hard
+
 "icss-utils@npm:^5.0.0, icss-utils@npm:^5.1.0":
   version: 5.1.0
   resolution: "icss-utils@npm:5.1.0"
@@ -15146,7 +16140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^7.0.0":
+"ignore@npm:^7.0.0, ignore@npm:^7.0.5":
   version: 7.0.5
   resolution: "ignore@npm:7.0.5"
   checksum: 10/f134b96a4de0af419196f52c529d5c6120c4456ff8a6b5a14ceaaa399f883e15d58d2ce651c9b69b9388491d4669dda47285d307e827de9304a53a1824801bc6
@@ -15181,18 +16175,6 @@ __metadata:
     parent-module: "npm:^1.0.0"
     resolve-from: "npm:^4.0.0"
   checksum: 10/a06b19461b4879cc654d46f8a6244eb55eb053437afd4cbb6613cad6be203811849ed3e4ea038783092879487299fda24af932b86bdfff67c9055ba3612b8c87
-  languageName: node
-  linkType: hard
-
-"import-in-the-middle@npm:^1.8.1":
-  version: 1.15.0
-  resolution: "import-in-the-middle@npm:1.15.0"
-  dependencies:
-    acorn: "npm:^8.14.0"
-    acorn-import-attributes: "npm:^1.9.5"
-    cjs-module-lexer: "npm:^1.2.2"
-    module-details-from-path: "npm:^1.0.3"
-  checksum: 10/a1ff65ea557ffe67e63dd67b411255fedd8622b324ff22ba99f4436b8fcf74da0333e62b4e8142f447e5db64a42ec9e65f926d50fa55e89c4e4d64626d8cf5f8
   languageName: node
   linkType: hard
 
@@ -15382,7 +16364,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
+"ip-address@npm:10.1.0, ip-address@npm:^10.0.1":
   version: 10.1.0
   resolution: "ip-address@npm:10.1.0"
   checksum: 10/a6979629d1ad9c1fb424bc25182203fad739b40225aebc55ec6243bbff5035faf7b9ed6efab3a097de6e713acbbfde944baacfa73e11852bb43989c45a68d79e
@@ -15396,7 +16378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ipaddr.js@npm:^2.0.1, ipaddr.js@npm:^2.1.0":
+"ipaddr.js@npm:^2.1.0":
   version: 2.3.0
   resolution: "ipaddr.js@npm:2.3.0"
   checksum: 10/be3d01bc2e20fc2dc5349b489ea40883954b816ce3e57aa48ad943d4e7c4ace501f28a7a15bde4b96b6b97d0fbb28d599ff2f87399f3cda7bd728889402eed3b
@@ -15700,6 +16682,13 @@ __metadata:
   dependencies:
     isobject: "npm:^3.0.1"
   checksum: 10/2a401140cfd86cabe25214956ae2cfee6fbd8186809555cd0e84574f88de7b17abacb2e477a6a658fa54c6083ecbda1e6ae404c7720244cd198903848fca70ca
+  languageName: node
+  linkType: hard
+
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: 10/0b46517ad47b00b6358fd6553c83ec1f6ba9acd7ffb3d30a0bf519c5c69e7147c132430452351b8a9fc198f8dd6c4f76f8e6f5a7f100f8c77d57d9e0f4261a8a
   languageName: node
   linkType: hard
 
@@ -16547,6 +17536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^6.1.3":
+  version: 6.2.3
+  resolution: "jose@npm:6.2.3"
+  checksum: 10/876974613c5ee988d43b65a34c96ce440dbf7706a2f07f465b8874af16ee532102e224459a7068d2c6ef044affe49690667d23ca12770c279804baec95a09608
+  languageName: node
+  linkType: hard
+
 "js-base64@npm:^3.7.2, js-base64@npm:^3.7.7":
   version: 3.7.8
   resolution: "js-base64@npm:3.7.8"
@@ -16609,6 +17605,7 @@ __metadata:
     "@octokit/auth-action": "npm:^4.0.1"
     bare-make: "npm:^1.5.1"
     cmake-bare: "npm:^1.6.5"
+    cmake-fetch: "npm:^1.4.7"
     detox: "npm:20.39.0"
     octokit: "npm:^4.0.2"
     ts-prune: "npm:^0.10.3"
@@ -16671,6 +17668,13 @@ __metadata:
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10/02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
+  languageName: node
+  linkType: hard
+
+"json-schema-typed@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "json-schema-typed@npm:8.0.2"
+  checksum: 10/fa866d1fe91e3a94aa4fe007861475cd03dcaf47b719861cab171ef2f8598478007c634d29ae45de94ee34ddff4e13414c63ea5ff06c5b868b613142c699d511
   languageName: node
   linkType: hard
 
@@ -16749,6 +17753,13 @@ __metadata:
     object.assign: "npm:^4.1.4"
     object.values: "npm:^1.1.6"
   checksum: 10/b61d44613687dfe4cc8ad4b4fbf3711bf26c60b8d5ed1f494d723e0808415c59b24a7c0ed8ab10736a40ff84eef38cbbfb68b395e05d31117b44ffc59d31edfc
+  languageName: node
+  linkType: hard
+
+"keypress@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "keypress@npm:0.2.1"
+  checksum: 10/d826101d51c819d16bf4f9b05bba73b8ee6c9f8aa2c09d425e9c8f901ca939b65920f986e4edcf9873e1447b319cb307cb44645947b3e341c4c43a4418d91ba7
   languageName: node
   linkType: hard
 
@@ -17136,6 +18147,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.isempty@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.isempty@npm:4.4.0"
+  checksum: 10/b69de4e08038f3d802fa2f510fd97f6b1785a359a648382ba30fb59e17ce0bcdad9bef2cdb9f9501abb9064c74c6edbb8db86a6d827e0d380a50a6738e051ec3
+  languageName: node
+  linkType: hard
+
+"lodash.isequal@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.isequal@npm:4.5.0"
+  checksum: 10/82fc58a83a1555f8df34ca9a2cd300995ff94018ac12cc47c349655f0ae1d4d92ba346db4c19bbfc90510764e0c00ddcc985a358bdcd4b3b965abf8f2a48a214
+  languageName: node
+  linkType: hard
+
+"lodash.kebabcase@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "lodash.kebabcase@npm:4.1.1"
+  checksum: 10/d84ec5441ef8e5c718c50315f35b0a045a77c7e8ee3e54472c06dc31f6f3602e95551a16c0923d689198b51deb8902c4bbc54fc9b965b26c1f86e21df3a05f34
+  languageName: node
+  linkType: hard
+
 "lodash.memoize@npm:^4.1.2":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
@@ -17161,6 +18193,13 @@ __metadata:
   version: 4.1.1
   resolution: "lodash.throttle@npm:4.1.1"
   checksum: 10/9be9fb2ffd686c20543167883305542f4564062a5f712a40e8c6f2f0d9fd8254a6e9d801c2470b1b24e0cdf2ae83c1277b55aa0fb4799a2db6daf545f53820e1
+  languageName: node
+  linkType: hard
+
+"lodash.unionwith@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.unionwith@npm:4.6.0"
+  checksum: 10/5056f77f6a6ebd7c186693941e9cfea47946b571c0e80c12724298147f5d416e32c951fb2800ec7ae15036ebd36f0ec15e7e9622c703810ebd1bf97c301f6da6
   languageName: node
   linkType: hard
 
@@ -17424,6 +18463,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: 10/a58dd60804df73c672942a7253ccc06815612326dc1c0827984b1a21704466d7cde351394f47649e56cf7415e6ee2e26e000e81b51b3eebb5a93540e8bf93cbd
+  languageName: node
+  linkType: hard
+
 "memfs@npm:^3.4.1":
   version: 3.5.3
   resolution: "memfs@npm:3.5.3"
@@ -17465,6 +18511,13 @@ __metadata:
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10/52117adbe0313d5defa771c9993fe081e2d2df9b840597e966aadafde04ae8d0e3da46bac7ca4efc37d4d2b839436582659cd49c6a43eacb3fe3050896a105d1
+  languageName: node
+  linkType: hard
+
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: 10/e383332e700a94682d0125a36c8be761142a1320fc9feeb18e6e36647c9edf064271645f5669b2c21cf352116e561914fd8aa831b651f34db15ef4038c86696a
   languageName: node
   linkType: hard
 
@@ -17756,7 +18809,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^3.0.1":
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.1, mime-types@npm:^3.0.2":
   version: 3.0.2
   resolution: "mime-types@npm:3.0.2"
   dependencies:
@@ -17797,17 +18850,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
+"minimalistic-assert@npm:^1.0.0":
   version: 1.0.1
   resolution: "minimalistic-assert@npm:1.0.1"
   checksum: 10/cc7974a9268fbf130fb055aff76700d7e2d8be5f761fb5c60318d0ed010d839ab3661a533ad29a5d37653133385204c503bfac995aaa4236f4e847461ea32ba7
-  languageName: node
-  linkType: hard
-
-"minimalistic-crypto-utils@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "minimalistic-crypto-utils@npm:1.0.1"
-  checksum: 10/6e8a0422b30039406efd4c440829ea8f988845db02a3299f372fceba56ffa94994a9c0f2fd70c17f9969eedfbd72f34b5070ead9656a34d3f71c0bd72583a0ed
   languageName: node
   linkType: hard
 
@@ -17820,12 +18866,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:9.0.3":
+  version: 9.0.3
+  resolution: "minimatch@npm:9.0.3"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/c81b47d28153e77521877649f4bab48348d10938df9e8147a58111fe00ef89559a2938de9f6632910c4f7bf7bb5cd81191a546167e58d357f0cfb1e18cecc1c5
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.1.1":
   version: 10.1.1
   resolution: "minimatch@npm:10.1.1"
   dependencies:
     "@isaacs/brace-expansion": "npm:^5.0.0"
   checksum: 10/110f38921ea527022e90f7a5f43721838ac740d0a0c26881c03b57c261354fb9a0430e40b2c56dfcea2ef3c773768f27210d1106f1f2be19cde3eea93f26f45e
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.2.2":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
+  dependencies:
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10/19e87a931aff60ee7b9d80f39f817b8bfc54f61f8356ee3549fbf636dbccacacfec8d803eac73293955c4527cd085247dfc064bce4a5e349f8f3b85e2bf5da0f
   languageName: node
   linkType: hard
 
@@ -17971,13 +19035,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"module-details-from-path@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "module-details-from-path@npm:1.0.4"
-  checksum: 10/2ebfada5358492f6ab496b70f70a1042f2ee7a4c79d29467f59ed6704f741fb4461d7cecb5082144ed39a05fec4d19e9ff38b731c76228151be97227240a05b2
-  languageName: node
-  linkType: hard
-
 "module-lookup-amd@npm:^9.0.3":
   version: 9.0.5
   resolution: "module-lookup-amd@npm:9.0.5"
@@ -18088,6 +19145,13 @@ __metadata:
   version: 1.0.0
   resolution: "mute-stream@npm:1.0.0"
   checksum: 10/36fc968b0e9c9c63029d4f9dc63911950a3bdf55c9a87f58d3a266289b67180201cade911e7699f8b2fa596b34c9db43dad37649e3f7fdd13c3bb9edb0017ee7
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mute-stream@npm:2.0.0"
+  checksum: 10/d2e4fd2f5aa342b89b98134a8d899d8ef9b0a6d69274c4af9df46faa2d97aeb1f2ce83d867880d6de63643c52386579b99139801e24e7526c3b9b0a6d1e18d6c
   languageName: node
   linkType: hard
 
@@ -18271,19 +19335,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nice-grpc-opentelemetry@npm:^0.1.18":
-  version: 0.1.20
-  resolution: "nice-grpc-opentelemetry@npm:0.1.20"
-  dependencies:
-    "@opentelemetry/api": "npm:^1.8.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.22.0"
-    abort-controller-x: "npm:^0.4.0"
-    ipaddr.js: "npm:^2.0.1"
-    nice-grpc-common: "npm:^2.0.2"
-  checksum: 10/a65fbf2f6181822e7dd2dabf472eec5baf5119d010d1006444af80002599d8d7bc981a02208897874a7055c4f9d661acdd139f72f5cf745002d818c63a04b791
-  languageName: node
-  linkType: hard
-
 "nice-grpc-web@npm:^3.3.7":
   version: 3.3.9
   resolution: "nice-grpc-web@npm:3.3.9"
@@ -18416,15 +19467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "node-addon-api@npm:5.1.0"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10/595f59ffb4630564f587c502119cbd980d302e482781021f3b479f5fc7e41cf8f2f7280fdc2795f32d148e4f3259bd15043c52d4a3442796aa6f1ae97b959636
-  languageName: node
-  linkType: hard
-
 "node-domexception@npm:^1.0.0":
   version: 1.0.0
   resolution: "node-domexception@npm:1.0.0"
@@ -18482,17 +19524,6 @@ __metadata:
   version: 1.3.3
   resolution: "node-forge@npm:1.3.3"
   checksum: 10/f41c31b9296771a4b8c955d58417471712f54f324603a35f8e6cbac19d5e6eaaf5fd5fd14584dfedecbf46a05438ded6eee60a5f2f0822fc5061aaa073cfc75d
-  languageName: node
-  linkType: hard
-
-"node-gyp-build@npm:^4.2.0":
-  version: 4.8.4
-  resolution: "node-gyp-build@npm:4.8.4"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 10/6a7d62289d1afc419fc8fc9bd00aa4e554369e50ca0acbc215cb91446148b75ff7e2a3b53c2c5b2c09a39d416d69f3d3237937860373104b5fe429bf30ad9ac5
   languageName: node
   linkType: hard
 
@@ -18859,7 +19890,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"optionator@npm:^0.9.3":
+"optionator@npm:^0.9.1, optionator@npm:^0.9.3":
   version: 0.9.4
   resolution: "optionator@npm:0.9.4"
   dependencies:
@@ -19153,7 +20184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parseurl@npm:~1.3.2, parseurl@npm:~1.3.3":
+"parseurl@npm:^1.3.3, parseurl@npm:~1.3.2, parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 10/407cee8e0a3a4c5cd472559bca8b6a45b82c124e9a4703302326e9ab60fc1081442ada4e02628efef1eb16197ddc7f8822f5a91fd7d7c86b51f530aedb17dfa2
@@ -19246,6 +20277,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:^8.0.0":
+  version: 8.4.2
+  resolution: "path-to-regexp@npm:8.4.2"
+  checksum: 10/70fd2cbce0b962cbcf4d312af07818bfce2bae11c09cf3bd86be99c0e30168238a1a7b02b18b452e73f075897df04597d30d63e56da7be41eecfc37998693389
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -19306,6 +20344,13 @@ __metadata:
   version: 4.0.7
   resolution: "pirates@npm:4.0.7"
   checksum: 10/2427f371366081ae42feb58214f04805d6b41d6b84d74480ebcc9e0ddbd7105a139f7c653daeaf83ad8a1a77214cf07f64178e76de048128fec501eab3305a96
+  languageName: node
+  linkType: hard
+
+"pkce-challenge@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "pkce-challenge@npm:5.0.1"
+  checksum: 10/51d11f68d5a78617cfb2e9c2706dadcc2cbe55ffb55b21d42a6ed848ac5159db2657bf6c966a5a414119aa839ceb64240afea35e9e1c06946b57606ed0b43789
   languageName: node
   linkType: hard
 
@@ -19712,7 +20757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-addr@npm:~2.0.7":
+"proxy-addr@npm:^2.0.7, proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
   dependencies:
@@ -19791,6 +20836,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.14.0, qs@npm:^6.14.1":
+  version: 6.15.1
+  resolution: "qs@npm:6.15.1"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10/ec10b9957446b3f4a38000940f6374720b4e2985209b89df197066038c951472ea24cd98d6bc6df73a0cbec75bc056f638032e3fb447345017ff7e0f0a2693ac
+  languageName: node
+  linkType: hard
+
 "quansync@npm:^0.2.7":
   version: 0.2.11
   resolution: "quansync@npm:0.2.11"
@@ -19865,6 +20919,18 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: 10/863b5171e140546a4d99f349b720abac4410338e23df5e409cfcc3752538c9caf947ce382c89129ba976f71894bd38b5806c774edac35ebf168d02aa1ac11a95
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "raw-body@npm:3.0.2"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.7.0"
+    unpipe: "npm:~1.0.0"
+  checksum: 10/4168c82157bd69175d5bd960e59b74e253e237b358213694946a427a6f750a18b8e150f036fed3421b3e83294b071a4e2bb01037a79ccacdac05360c63d3ebba
   languageName: node
   linkType: hard
 
@@ -20084,7 +21150,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:^4.16.0":
+"react-native-screens@npm:~4.18.0":
   version: 4.18.0
   resolution: "react-native-screens@npm:4.18.0"
   dependencies:
@@ -20450,17 +21516,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"require-in-the-middle@npm:^7.1.1":
-  version: 7.5.2
-  resolution: "require-in-the-middle@npm:7.5.2"
-  dependencies:
-    debug: "npm:^4.3.5"
-    module-details-from-path: "npm:^1.0.3"
-    resolve: "npm:^1.22.8"
-  checksum: 10/d8f137d72eec1c53987647d19cd3bd2c64d5417bcd06b9ac8f7a14e83924c1e7636e327df7d96066a2b446b41f50d0bc1856a521388d5e90ba5c3b18dd5ab4e8
-  languageName: node
-  linkType: hard
-
 "require-main-filename@npm:^2.0.0":
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
@@ -20581,7 +21636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.20.0, resolve@npm:^1.22.10, resolve@npm:^1.22.2, resolve@npm:^1.22.3, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
+"resolve@npm:^1.20.0, resolve@npm:^1.22.10, resolve@npm:^1.22.2, resolve@npm:^1.22.3, resolve@npm:^1.22.4":
   version: 1.22.11
   resolution: "resolve@npm:1.22.11"
   dependencies:
@@ -20616,7 +21671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.3#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.3#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.11
   resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
   dependencies:
@@ -20734,23 +21789,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown-plugin-dts@npm:^0.21.1":
-  version: 0.21.2
-  resolution: "rolldown-plugin-dts@npm:0.21.2"
+"rolldown-plugin-dts@npm:^0.22.1":
+  version: 0.22.5
+  resolution: "rolldown-plugin-dts@npm:0.22.5"
   dependencies:
-    "@babel/generator": "npm:^7.28.6"
-    "@babel/parser": "npm:^7.28.6"
-    "@babel/types": "npm:^7.28.6"
-    ast-kit: "npm:^2.2.0"
+    "@babel/generator": "npm:8.0.0-rc.2"
+    "@babel/helper-validator-identifier": "npm:8.0.0-rc.2"
+    "@babel/parser": "npm:8.0.0-rc.2"
+    "@babel/types": "npm:8.0.0-rc.2"
+    ast-kit: "npm:^3.0.0-beta.1"
     birpc: "npm:^4.0.0"
     dts-resolver: "npm:^2.1.3"
-    get-tsconfig: "npm:^4.13.0"
+    get-tsconfig: "npm:^4.13.6"
     obug: "npm:^2.1.1"
   peerDependencies:
     "@ts-macro/tsc": ^0.3.6
     "@typescript/native-preview": ">=7.0.0-dev.20250601.1"
-    rolldown: ^1.0.0-beta.57
-    typescript: ^5.0.0
+    rolldown: ^1.0.0-rc.3
+    typescript: ^5.0.0 || ^6.0.0-beta
     vue-tsc: ~3.2.0
   peerDependenciesMeta:
     "@ts-macro/tsc":
@@ -20761,29 +21817,87 @@ __metadata:
       optional: true
     vue-tsc:
       optional: true
-  checksum: 10/7c880a68d846016eff0be24298db60b5ddbc41c6b3f7da72402423318c47e55cffca6892c6234775c65b6372b12cd0cd88bf23cef957a1a83dc6f9712561027a
+  checksum: 10/aa16b14e1d4477760695e4e982b19dc9b51426501caa2ccbb38fa6b52c9dd8db4fac1691e03397810efdbad32111586c4ce8108ee5c3fc39dcaa556ada76aeae
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.0-beta.60":
-  version: 1.0.0-beta.60
-  resolution: "rolldown@npm:1.0.0-beta.60"
+"rolldown@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "rolldown@npm:1.0.0-rc.17"
   dependencies:
-    "@oxc-project/types": "npm:=0.108.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.0-beta.60"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.0-beta.60"
-    "@rolldown/binding-darwin-x64": "npm:1.0.0-beta.60"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.0-beta.60"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-beta.60"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-beta.60"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-beta.60"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-beta.60"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-beta.60"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-beta.60"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-beta.60"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-beta.60"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-beta.60"
-    "@rolldown/pluginutils": "npm:1.0.0-beta.60"
+    "@oxc-project/types": "npm:=0.127.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.17"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.17"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.17"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.17"
+    "@rolldown/pluginutils": "npm:1.0.0-rc.17"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: bin/cli.mjs
+  checksum: 10/5e7415a7cb732c4f7168ab6dcc841ed9ec4ad614058294a53d94821a762c274a69b009e41e9c8e4983a059907f02d462030a36b42543c0f41ce702fcd68d10d5
+  languageName: node
+  linkType: hard
+
+"rolldown@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "rolldown@npm:1.0.0-rc.3"
+  dependencies:
+    "@oxc-project/types": "npm:=0.112.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.3"
+    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.3"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.3"
+    "@rolldown/pluginutils": "npm:1.0.0-rc.3"
   dependenciesMeta:
     "@rolldown/binding-android-arm64":
       optional: true
@@ -20813,7 +21927,7 @@ __metadata:
       optional: true
   bin:
     rolldown: bin/cli.mjs
-  checksum: 10/6018351afb38669624c4afeba7fd6e48114405e88ef79b3ff9f21e7738d7580b3c9c1d679421092807d05b95cae8ed0a6490df3075f01012519333a78ca8545e
+  checksum: 10/28c88da3dc1b95125e177c4fd0757faffdd4b2fa81ef0a0ba6e75f5e4c4c49c5a3fe88dd7fffe9f7091d514cd25fa0a038d03acbe7068651b1b43a5257edfd03
   languageName: node
   linkType: hard
 
@@ -20895,6 +22009,19 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10/e2eff82405061fa907f15dfbf742b1f5fb4b214495c00989bcdbe21da5fcb3f6dec3deabacec491300a53c99da409586cfc77bdf29b411fccb9089b72cd3728d
+  languageName: node
+  linkType: hard
+
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    is-promise: "npm:^4.0.0"
+    parseurl: "npm:^1.3.3"
+    path-to-regexp: "npm:^8.0.0"
+  checksum: 10/8949bd1d3da5403cc024e2989fee58d7fda0f3ffe9f2dc5b8a192f295f400b3cde307b0b554f7d44851077640f36962ca469a766b3d57410d7d96245a7ba6c91
   languageName: node
   linkType: hard
 
@@ -21089,18 +22216,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"secp256k1@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "secp256k1@npm:5.0.1"
-  dependencies:
-    elliptic: "npm:^6.5.7"
-    node-addon-api: "npm:^5.0.0"
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.2.0"
-  checksum: 10/63fbd35624be4fd9cf3d39e5f79c5471b4a8aea6944453b2bea7b100bb1c77a25c55e6e08e2210cdabdf478c4c62d34c408b34214f2afd9367e19a52a3a4236c
-  languageName: node
-  linkType: hard
-
 "select-hose@npm:^2.0.0":
   version: 2.0.0
   resolution: "select-hose@npm:2.0.0"
@@ -21212,6 +22327,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "send@npm:1.2.1"
+  dependencies:
+    debug: "npm:^4.4.3"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.1"
+    mime-types: "npm:^3.0.2"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.2"
+  checksum: 10/274f842d69ccfa49d4940a85598c6825da58dee6cb8ea33b08d5bd3988e6a82267c4d7c32b23d0e4706aad076ee95b1edfa13f859877db9b589829019397e355
+  languageName: node
+  linkType: hard
+
 "serialize-error@npm:^2.1.0":
   version: 2.1.0
   resolution: "serialize-error@npm:2.1.0"
@@ -21261,6 +22395,18 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:0.19.0"
   checksum: 10/7fa9d9c68090f6289976b34fc13c50ac8cd7f16ae6bce08d16459300f7fc61fbc2d7ebfa02884c073ec9d6ab9e7e704c89561882bbe338e99fcacb2912fde737
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "serve-static@npm:2.2.1"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 10/71500fe80cc7163fec04e4297de7591ad1cb682d137fc030e7a53e57040fda5187e8082a9c1b2ef37f1d3f9c27c9a94d4ba61806ebc28938ba4a7c8947c9f71e
   languageName: node
   linkType: hard
 
@@ -21534,7 +22680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
@@ -21726,7 +22872,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "spark-browser-extension@workspace:examples/spark-browser-extension"
   dependencies:
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@types/chrome": "npm:^0.0.276"
     esbuild: "npm:^0.25.0"
     prettier: "npm:^3.7.4"
@@ -21738,7 +22884,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "spark-nextjs-app@workspace:examples/spark-nextjs-app"
   dependencies:
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     "@eslint/eslintrc": "npm:^3"
     "@tailwindcss/postcss": "npm:^4"
     "@types/node": "npm:^22.13.2"
@@ -21759,10 +22905,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "spark-node-express@workspace:examples/spark-node-express"
   dependencies:
-    "@buildonspark/issuer-sdk": "npm:0.1.13"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
-    "@lightsparkdev/core": "npm:^1.4.4"
-    "@noble/curves": "npm:^1.8.0"
+    "@buildonspark/issuer-sdk": "npm:0.1.35"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
+    "@lightsparkdev/core": "npm:^1.5.0"
+    "@noble/curves": "npm:^1.9.7"
     "@types/express": "npm:^5.0.3"
     "@types/node": "npm:^22.13.2"
     cross-env: "npm:^7.0.3"
@@ -21782,7 +22928,7 @@ __metadata:
     "@babel/core": "npm:^7.27.3"
     "@babel/preset-env": "npm:^7.27.2"
     "@babel/preset-react": "npm:^7.27.1"
-    "@buildonspark/spark-sdk": "npm:0.6.3"
+    "@buildonspark/spark-sdk": "npm:0.7.17"
     babel-loader: "npm:^10.0.0"
     css-loader: "npm:^7.1.2"
     html-webpack-plugin: "npm:^5.6.3"
@@ -21909,7 +23055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:~2.0.1, statuses@npm:~2.0.2":
+"statuses@npm:^2.0.1, statuses@npm:^2.0.2, statuses@npm:~2.0.1, statuses@npm:~2.0.2":
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 10/6927feb50c2a75b2a4caab2c565491f7a93ad3d8dbad7b1398d52359e9243a20e2ebe35e33726dee945125ef7a515e9097d8a1b910ba2bbd818265a2f6c39879
@@ -21962,6 +23108,17 @@ __metadata:
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
   checksum: 10/612c2b2a7dbcc859f74597112f80a42cbe4d448d03da790d5b7b39673c1197dd3789e91cd67210353e58857395d32c1e955a9041c4e6d5bae723436b3ed9ed14
+  languageName: node
+  linkType: hard
+
+"streamx@npm:^2.12.5, streamx@npm:^2.25.0":
+  version: 2.25.0
+  resolution: "streamx@npm:2.25.0"
+  dependencies:
+    events-universal: "npm:^1.0.0"
+    fast-fifo: "npm:^1.3.2"
+    text-decoder: "npm:^1.1.0"
+  checksum: 10/d00dd38a1b73e4dac5225344aee421eb12ba9dded3f0ee3427d358d663677af185bc2310f46cb85ff3da31e032a50514d6f66348ba756154fe8a89b845273a3c
   languageName: node
   linkType: hard
 
@@ -22409,6 +23566,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar@npm:^7.0.0":
+  version: 7.5.13
+  resolution: "tar@npm:7.5.13"
+  dependencies:
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10/2bc2b6f0349038a6621dbba1c4522d45752d5071b2994692257113c2050cd23fafc30308f820e5f8ad6fda3f7d7f92adc9a432aa733daa04c42af2061c021c3f
+  languageName: node
+  linkType: hard
+
 "tar@npm:^7.4.3, tar@npm:^7.5.2":
   version: 7.5.2
   resolution: "tar@npm:7.5.2"
@@ -22419,6 +23589,15 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10/dbad9c9a07863cd1bdf8801d563b3280aa7dd0f4a6cead779ff7516d148dc80b4c04639ba732d47f91f04002f57e8c3c6573a717d649daecaac74ce71daa7ad3
+  languageName: node
+  linkType: hard
+
+"teex@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "teex@npm:1.0.1"
+  dependencies:
+    streamx: "npm:^2.12.5"
+  checksum: 10/36bf7ce8bb5eb428ad7b14b695ee7fb0a02f09c1a9d8181cc42531208543a920b299d711bf78dad4ff9bcf36ac437ae8e138053734746076e3e0e7d6d76eef64
   languageName: node
   linkType: hard
 
@@ -22734,7 +23913,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^1.3.0":
+"ts-api-utils@npm:^1.0.1, ts-api-utils@npm:^1.3.0":
   version: 1.4.3
   resolution: "ts-api-utils@npm:1.4.3"
   peerDependencies:
@@ -22749,6 +23928,15 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10/02e55b49d9617c6eebf8aadfa08d3ca03ca0cd2f0586ad34117fdfc7aa3cd25d95051843fde9df86665ad907f99baed179e7a117b11021417f379e4d2614eacd
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "ts-api-utils@npm:2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4"
+  checksum: 10/d5f1936f5618c6ab6942a97b78802217540ced00e7501862ae1f578d9a3aa189fc06050e64cb8951d21f7088e5fd35f53d2bf0d0370a883861c7b05e993ebc44
   languageName: node
   linkType: hard
 
@@ -22965,9 +24153,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsdown@npm:^0.20.0-beta.3":
-  version: 0.20.0-beta.3
-  resolution: "tsdown@npm:0.20.0-beta.3"
+"tsdown@npm:^0.20.3":
+  version: 0.20.3
+  resolution: "tsdown@npm:0.20.3"
   dependencies:
     ansis: "npm:^4.2.0"
     cac: "npm:^6.7.14"
@@ -22977,14 +24165,14 @@ __metadata:
     import-without-cache: "npm:^0.2.5"
     obug: "npm:^2.1.1"
     picomatch: "npm:^4.0.3"
-    rolldown: "npm:1.0.0-beta.60"
-    rolldown-plugin-dts: "npm:^0.21.1"
+    rolldown: "npm:1.0.0-rc.3"
+    rolldown-plugin-dts: "npm:^0.22.1"
     semver: "npm:^7.7.3"
     tinyexec: "npm:^1.0.2"
     tinyglobby: "npm:^0.2.15"
     tree-kill: "npm:^1.2.2"
     unconfig-core: "npm:^7.4.2"
-    unrun: "npm:^0.2.25"
+    unrun: "npm:^0.2.27"
   peerDependencies:
     "@arethetypeswrong/core": ^0.18.1
     "@vitejs/devtools": "*"
@@ -23007,7 +24195,7 @@ __metadata:
       optional: true
   bin:
     tsdown: dist/run.mjs
-  checksum: 10/660ebe49cd9fc637d29b649bdc4d71d1bc3f1e9c4b77ef574b27621fad74eb2d9b600b28e45099de7437826c6cdd5d2b4b842f184e808f5dcfca86ddb27b0dd0
+  checksum: 10/3d511dea766ebdd3b1c4387aa86a7093a2e4fe131c6283a73453545ffdf48f30f1a3694c4a9a45068a58ccab3d886ddfd3a89b898b0b5e5f7469a72da8ecc49e
   languageName: node
   linkType: hard
 
@@ -23177,6 +24365,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-is@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "type-is@npm:2.0.1"
+  dependencies:
+    content-type: "npm:^1.0.5"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10/bacdb23c872dacb7bd40fbd9095e6b2fca2895eedbb689160c05534d7d4810a7f4b3fd1ae87e96133c505958f6d602967a68db5ff577b85dd6be76eaa75d58af
+  languageName: node
+  linkType: hard
+
 "typed-array-buffer@npm:^1.0.3":
   version: 1.0.3
   resolution: "typed-array-buffer@npm:1.0.3"
@@ -23241,6 +24440,21 @@ __metadata:
   version: 1.18.0
   resolution: "typeforce@npm:1.18.0"
   checksum: 10/dbf98c75b1d57e56e33c1e1271d5505e67981f4e6a2e2e6e8e31160b58777fea1726160810b6c606517db16476805b7dce315926ba2d4859b9a56cab05b7a41f
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^8.0.0":
+  version: 8.59.2
+  resolution: "typescript-eslint@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:8.59.2"
+    "@typescript-eslint/parser": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/utils": "npm:8.59.2"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/f729dffc5e2beef2685d7fdc5ecac973c02cad30d24929a5cc4df5d94b58d8841f34e06c87cf9df14caae7a0c264e4371d9c5b59b7210ce769519417c8494698
   languageName: node
   linkType: hard
 
@@ -23594,11 +24808,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unrun@npm:^0.2.25":
-  version: 0.2.25
-  resolution: "unrun@npm:0.2.25"
+"unrun@npm:^0.2.27":
+  version: 0.2.37
+  resolution: "unrun@npm:0.2.37"
   dependencies:
-    rolldown: "npm:1.0.0-beta.60"
+    rolldown: "npm:1.0.0-rc.17"
   peerDependencies:
     synckit: ^0.11.11
   peerDependenciesMeta:
@@ -23606,7 +24820,7 @@ __metadata:
       optional: true
   bin:
     unrun: dist/cli.mjs
-  checksum: 10/76c6f57245c6023cef008f57f3030baf4dab173b2c767ccc7492036555758e66c828c628831f8b5a81e8ef5c27cc39d46c39d128c9c5f303fb8fa4a57e05add7
+  checksum: 10/5847f245207e593af2bd943863fa07cc83da53b91955d6896f244c1c634850bda4dc5ad174aecbad241fa361d1450145bc6d0c66e99e797f7a96e9bc0c4c2f4a
   languageName: node
   linkType: hard
 
@@ -23756,7 +24970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vary@npm:^1, vary@npm:~1.1.2":
+"vary@npm:^1, vary@npm:^1.1.2, vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10/31389debef15a480849b8331b220782230b9815a8e0dbb7b9a8369559aed2e9a7800cd904d4371ea74f4c3527db456dc8e7ac5befce5f0d289014dbdf47b2242
@@ -24656,6 +25870,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yoctocolors-cjs@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "yoctocolors-cjs@npm:2.1.3"
+  checksum: 10/b2144b38807673a4254dae06fe1a212729550609e606289c305e45c585b36fab1dbba44fe6cde90db9b28be465ec63f4c2a50867aeec6672f6bc36b6c9a361a0
+  languageName: node
+  linkType: hard
+
 "yoga-layout@npm:~3.2.1":
   version: 3.2.1
   resolution: "yoga-layout@npm:3.2.1"
@@ -24676,5 +25897,28 @@ __metadata:
   version: 0.8.15
   resolution: "zen-observable@npm:0.8.15"
   checksum: 10/30eac3f4055d33f446b4cd075d3543da347c2c8e68fbc35c3f5a19fb43be67c6ed27ee136bc8f8933efa547be7ce04957809ad00ee7f1b00a964f199ae6fb514
+  languageName: node
+  linkType: hard
+
+"zod-to-json-schema@npm:^3.25.1":
+  version: 3.25.2
+  resolution: "zod-to-json-schema@npm:3.25.2"
+  peerDependencies:
+    zod: ^3.25.28 || ^4
+  checksum: 10/7035328654113f1a0b8e4c2d34a06f918c93650ef8a50d4fb30ad8f22e47d5762c163af9c82494756b34776bae3c41c26cfc6945105b0eee7dceb528cc07e665
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.24.0":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10/f0c963ec40cd96858451d1690404d603d36507c1fc9682f2dae59ab38b578687d542708a7fdbf645f77926f78c9ed558f57c3d3aa226c285f798df0c4da16995
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25 || ^4.0":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary

Adds a Bare repro script for the agent suspend/resume balance behavior in `spark-bare-app`, including explicit `bare-http1` / `bare-https` dependencies so the example resolves agent implementations that expose `suspend()` and `resume()`.

The script now defaults to Nam's direct-await case:
- enable SDK logging at TRACE by default
- suspend the Bare HTTP/HTTPS agents
- call `await wallet.getBalance()` directly while suspended, without wrapping that suspended balance call in `Promise.race`

The earlier watchdog comparison flow is still available with `REPRO_MODE=race`.

Included captured logs:
- `repro-agent-suspend-balance-direct.log`: direct suspended `getBalance()` rejects immediately with `AGENT_SUSPENDED`, then cleanup exits normally.
- `repro-agent-suspend-balance-direct-no-cleanup.log`: direct suspended `getBalance()` rejects immediately, but without cleanup the process remains alive on the background stream until the external timeout kills it.
- Earlier race-mode logs are retained for comparison.

## Findings

I was still not able to reproduce a foreground `getBalance()` call hanging forever. With SDK TRACE logging enabled and no `Promise.race` around the suspended balance call, the captured direct log shows BareHttpTransport failing request setup with `AGENT_SUSPENDED` and `getBalance()` rejecting in the same tick range.

The process-liveness issue remains reproducible: the no-cleanup direct run prints `repro script completed`, then continues receiving `subscribe_to_events` chunks until the external 45s timeout exits with code 124.

## Public

Adds a public Bare repro script and captured logs for agent suspend/resume balance behavior. No production SDK behavior is changed.

## Validation

- `yarn install --immutable`
- `yarn workspace @buildonspark/spark-bare-app format`
- `timeout 45 env WATCHDOG_MS=20000 NETWORK=MAINNET yarn workspace @buildonspark/spark-bare-app repro:agent-suspend-balance`
- `timeout 45 env WATCHDOG_MS=20000 CLEANUP_CONNECTIONS=0 NETWORK=MAINNET yarn workspace @buildonspark/spark-bare-app repro:agent-suspend-balance`
