### PR TITLE
Add security policy with reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The preferred channel for reporting security vulnerabilities is our bug bounty program on Immunefi:
+
+https://immunefi.com/bug-bounty/spark-lightspark/
+
+If you are unable to use Immunefi for any reason, you may report vulnerabilities privately using GitHub Private Vulnerability Reporting (available under the Security tab of this repository), or by emailing the maintainers directly.
+
+Please include, whenever possible:
+
+- A clear description of the issue
+- Affected components and commit hashes
+- Step-by-step reproduction instructions
+- Proof-of-concept code or test cases
+- Impact assessment and suggested severity
+- Proposed mitigations or patches (optional)
+
+## Reward Eligibility
+
+Valid security findings submitted through GitHub Private Vulnerability Reporting or via email will be evaluated under the same criteria and reward tiers as our Immunefi bug bounty program, provided they meet the same scope, impact, and disclosure requirements.
+
+Researchers who are unable to use Immunefi will not be disadvantaged solely because they used an alternative private reporting channel.
+
+## Coordinated Disclosure
+
+Please do not publicly disclose vulnerabilities until the issue has been resolved and we have agreed on a disclosure timeline.
+
+We will acknowledge receipt of your report as soon as possible and aim to keep you informed throughout the remediation process.
+
+## Safe Harbor
+
+We support responsible security research conducted in good faith and will not pursue legal action against researchers who:
+
+- Avoid violating privacy or disrupting service availability
+- Do not access or modify user funds or data beyond what is necessary to demonstrate the issue
+- Give us a reasonable opportunity to remediate the issue before public disclosure
+
+Thank you for helping us keep Spark secure.


### PR DESCRIPTION
## Summary

This PR adds a SECURITY.md file that documents:

- The primary vulnerability disclosure channel through Immunefi
- An alternative private reporting channel for researchers who are unable to access Immunefi
- Reward eligibility parity for valid reports submitted outside Immunefi
- Coordinated disclosure expectations
- Safe harbor language for good-faith security research

## Why this is useful

While Spark already has an active bug bounty program on Immunefi, adding a SECURITY.md provides a standard, repository-native security policy and ensures that researchers can quickly find the preferred disclosure process directly from the repository.

It also establishes a fallback private reporting path for legitimate researchers who cannot access Immunefi for technical or account-related reasons.

## Additional Maintainer Action Required

To enable GitHub's built-in private disclosure workflow referenced in this policy, maintainers will need to enable Private Vulnerability Reporting in the repository settings:

Repository → Settings → Security → Advanced Security → Private vulnerability reporting → Enable

Once enabled, a "Report a vulnerability" button will appear under the Security tab, allowing researchers to submit reports privately through GitHub Security Advisories.

## Reward Eligibility

The proposed policy states that valid reports submitted through GitHub Private Vulnerability Reporting should be evaluated under the same criteria and reward tiers as the existing Immunefi program.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a repository security policy; no code paths or runtime behavior are affected.
> 
> **Overview**
> Adds a new `SECURITY.md` documenting the preferred vulnerability reporting channel (Immunefi) with alternative private reporting options (GitHub private vulnerability reporting or email), plus expectations around reward eligibility parity, coordinated disclosure, and safe-harbor guidelines for good-faith research.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 716da753ca3d7fbbc76177883bdc2f62ad29d26e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->