### PR TITLE
Chore: Export utilities from htlc-transactions

### DIFF
--- a/sdks/js/packages/spark-sdk/src/utils/index.ts
+++ b/sdks/js/packages/spark-sdk/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from "./address.js";
 export * from "./adaptor-signature.js";
 export * from "./bitcoin.js";
 export * from "./hashstructure.js";
+export * from "./htlc-transactions.js";
 export * from "./idempotency.js";
 export * from "./keys.js";
 export * from "./mempool.js";


### PR DESCRIPTION
These are required by the Turnkey integration code - see [this PR](https://github.com/tkhq/sdk/pull/1322/changes#diff-fd0d29c19e2c5ec81a95bf4bd56a1474bf745e8ef036734432c33a1de84545cd) in Turnkey SDK.