### PR TITLE
Chore: Expose SigningService & TransferService

### DIFF
--- a/sdks/js/packages/spark-sdk/src/index-shared.ts
+++ b/sdks/js/packages/spark-sdk/src/index-shared.ts
@@ -28,7 +28,9 @@ export * from "./spark-readonly-client/types.js";
 export * from "./spark-wallet/types.js";
 
 export { type WalletConfigService } from "./services/config.js";
+export { SigningService } from "./services/signing.js";
 export { TokenTransactionService } from "./services/tokens/token-transactions.js";
+export { TransferService } from "./services/transfer.js";
 export {
   WalletConfig,
   createLocalSigningOperators,


### PR DESCRIPTION
Me again 🤣 Would it be possible to export the `TransferService` and `SigningService`?

We have a need for a custom implementation of the claiming logic that would be the nicest if we'd have compile-time access to these two.