### PR TITLE
Make TransferService::prepareClaimPackage protected

### DIFF
--- a/sdks/js/packages/spark-sdk/src/services/transfer.ts
+++ b/sdks/js/packages/spark-sdk/src/services/transfer.ts
@@ -15,6 +15,7 @@ import { SignatureIntent } from "../proto/common.js";
 import {
   type ClaimLeafKeyTweak,
   ClaimLeafKeyTweaks,
+  type ClaimPackage,
   type ClaimTransferResponse,
   type ClaimTransferSignRefundsResponse,
   type CounterLeafSwapResponse,
@@ -1571,7 +1572,7 @@ export class TransferService extends BaseTransferService {
   protected async prepareClaimPackage(
     transferId: string,
     leaves: LeafKeyTweak[],
-  ) {
+  ): Promise<ClaimPackage> {
     // 1. Prepare key tweaks per SO
     const leavesTweaksMap = await this.prepareClaimLeavesKeyTweaks(leaves);
 
@@ -1647,7 +1648,7 @@ export class TransferService extends BaseTransferService {
     );
 
     // 7. Assemble and sign ClaimPackage
-    const claimPackage = {
+    const claimPackage: ClaimPackage = {
       leavesToClaim: cpfpLeafSigningJobs,
       keyTweakPackage,
       userSignature: new Uint8Array(),

--- a/sdks/js/packages/spark-sdk/src/services/transfer.ts
+++ b/sdks/js/packages/spark-sdk/src/services/transfer.ts
@@ -1568,7 +1568,7 @@ export class TransferService extends BaseTransferService {
     }
   }
 
-  private async prepareClaimPackage(
+  protected async prepareClaimPackage(
     transferId: string,
     leaves: LeafKeyTweak[],
   ) {


### PR DESCRIPTION
In order to be able to make a very isolated, Turnkey-compatible claim flow change. A return type has been added as well.