### PR TITLE
Fix: Hanging promise in TransferService

### DIFF
--- a/sdks/js/packages/spark-sdk/src/services/transfer.ts
+++ b/sdks/js/packages/spark-sdk/src/services/transfer.ts
@@ -202,6 +202,8 @@ export class BaseTransferService {
   protected readonly signingService: SigningService;
   protected readonly logger: Logger;
 
+  protected destroyed = false;
+
   constructor(
     config: WalletConfigService,
     connectionManager: ConnectionManager,
@@ -213,6 +215,16 @@ export class BaseTransferService {
     this.connectionManager = connectionManager;
     this.signingService = signingService;
     this.logger = logging.logger(serviceName);
+  }
+
+  async cleanup() {
+    this.destroyed = true;
+  }
+
+  protected assertNotDestroyed(message: string): asserts this is { destroyed: false } {
+    if (this.destroyed) {
+      throw new SparkError(message);
+    }
   }
 
   async deliverTransferPackage(
@@ -2401,6 +2413,8 @@ export class TransferService extends BaseTransferService {
     const onError = async (
       context: RetryContext<TreeNode[], Transfer>,
     ): Promise<TreeNode[] | undefined> => {
+      this.assertNotDestroyed("Claim transfer process was interrupted due to cleanup");
+
       const error = context.error;
       if (
         error instanceof SparkRequestError &&
@@ -2427,6 +2441,8 @@ export class TransferService extends BaseTransferService {
     };
 
     const fetchData = async (context: RetryContext<TreeNode[], Transfer>) => {
+      this.assertNotDestroyed("Claim transfer process was interrupted due to cleanup");
+
       const transferToUse = context.data || transfer;
       const updatedTransfer = await this.queryPendingTransfers({
         transferIds: [transferToUse.id],

--- a/sdks/js/packages/spark-sdk/src/spark-wallet/spark-wallet.ts
+++ b/sdks/js/packages/spark-sdk/src/spark-wallet/spark-wallet.ts
@@ -6141,7 +6141,10 @@ export abstract class SparkWallet extends EventEmitter<SparkWalletEvents> {
   public async cleanup() {
     this.cleanupState();
     try {
-      await this.connectionManager.closeConnections();
+      await Promise.allSettled([
+        this.connectionManager.closeConnections(),
+        this.transferService.cleanup(),
+      ])
     } finally {
       await this.logging.close();
     }


### PR DESCRIPTION
While testing, I discovered that the `SparkWallet::cleanup` has an edge case in which the `TransferService` would still try to queue a new claim while the wallet has already been cleaned up. This PR fixes that issue by introducing a `cleanup` method to `TransferService`.