### PR TITLE
Chore: Make SparkWallet::{claimTransfer,transferWithInvoice} protected

### DIFF
--- a/sdks/js/packages/spark-sdk/src/spark-wallet/spark-wallet.ts
+++ b/sdks/js/packages/spark-sdk/src/spark-wallet/spark-wallet.ts
@@ -3155,7 +3155,7 @@ export abstract class SparkWallet extends EventEmitter<SparkWalletEvents> {
    * @returns {Promise<TransferWithInvoiceOutcome[]>} The outcomes of the transfers
    * @private
    */
-  private async transferWithInvoice(
+  protected async transferWithInvoice(
     params: TransferWithInvoiceParams[],
   ): Promise<TransferWithInvoiceOutcome[]> {
     const amountSatsArray: number[] = [];

--- a/sdks/js/packages/spark-sdk/src/spark-wallet/spark-wallet.ts
+++ b/sdks/js/packages/spark-sdk/src/spark-wallet/spark-wallet.ts
@@ -3302,7 +3302,7 @@ export abstract class SparkWallet extends EventEmitter<SparkWalletEvents> {
    * @param {Transfer} transfer - The transfer to claim
    * @returns {Promise<Object>} The claim result
    */
-  private async claimTransfer({
+  protected async claimTransfer({
     transfer,
     emit,
   }: {


### PR DESCRIPTION
Yet another one - sorry. For localized Turnkey-specific flow overrides.