### PR TITLE
Chore: Export LeafKeyTweak from transfer

### DIFF
--- a/sdks/js/packages/spark-sdk/src/index-shared.ts
+++ b/sdks/js/packages/spark-sdk/src/index-shared.ts
@@ -30,7 +30,7 @@ export * from "./spark-wallet/types.js";
 export { type WalletConfigService } from "./services/config.js";
 export { SigningService } from "./services/signing.js";
 export { TokenTransactionService } from "./services/tokens/token-transactions.js";
-export { TransferService } from "./services/transfer.js";
+export { type LeafKeyTweak, TransferService } from "./services/transfer.js";
 export {
   WalletConfig,
   createLocalSigningOperators,


### PR DESCRIPTION
So that we don't need to redeclare it on our side at Turnkey