### PR TITLE
fix(sdk): surface unilateral exit refund after node tx confirms (stateless resume)

### DIFF
--- a/sdks/js/packages/spark-sdk/src/tests/unilateral-exit.test.ts
+++ b/sdks/js/packages/spark-sdk/src/tests/unilateral-exit.test.ts
@@ -7,8 +7,10 @@ import { sha256 } from "@noble/hashes/sha2";
 import * as btc from "@scure/btc-signer";
 
 import { TreeNode } from "../proto/spark.js";
+import { getTxFromRawTxHex, getTxId } from "../utils/bitcoin.js";
 import { Network } from "../utils/network.js";
 import { constructUnilateralExitFeeBumpPackages } from "../utils/unilateral-exit.js";
+import { BitcoinFaucet } from "./utils/test-faucet.js";
 
 function hash160(data: Uint8Array): Uint8Array {
   return ripemd160(sha256(data));
@@ -160,4 +162,150 @@ describe("unilateral exit", () => {
     }
     expect(collisions).toEqual([]);
   });
+});
+
+describe("unilateral exit stateless resume", () => {
+  // A unilateral exit is two-phase: the exit chain is broadcast first, and
+  // the leaf's CSV-timelocked refund is broadcast once the timelock matures.
+  // A caller that rebuilds packages from chain state on a later run must
+  // keep receiving the leaf's refund until that refund (or an equivalent
+  // direct variant, which is what a watchtower broadcasts) is itself on
+  // chain; otherwise the exit silently completes with the leaf's value
+  // stranded in the timelock-encumbered node output.
+  const fundingPrivateKey = hexToBytes("07".repeat(32));
+  const fundingPublicKey = secp256k1.getPublicKey(fundingPrivateKey);
+  const fundingUtxo = {
+    txid: "11".repeat(32),
+    vout: 0,
+    value: 100_000n,
+    script: bytesToHex(
+      new Uint8Array([0x00, 0x14, ...hash160(fundingPublicKey)]),
+    ),
+    publicKey: bytesToHex(fundingPublicKey),
+  };
+
+  const makeLeaf = (id: string, parentSeed: string): TreeNode =>
+    TreeNode.fromPartial({
+      id,
+      nodeTx: makeTrucParentBytes(parentSeed, 0),
+      refundTx: makeTrucParentBytes(parentSeed, 1),
+      status: "AVAILABLE",
+    });
+
+  const txidOf = (txBytes: Uint8Array): string =>
+    getTxId(getTxFromRawTxHex(bytesToHex(txBytes)));
+
+  let getRawTransactionSpy: jest.SpiedFunction<
+    BitcoinFaucet["getRawTransaction"]
+  >;
+
+  // isTxBroadcast(Network.LOCAL) resolves through the faucet's
+  // getRawTransaction: a resolved call means the tx is on chain, a rejected
+  // call means it is not.
+  const setOnChainTxids = (onChainTxids: ReadonlySet<string>) => {
+    getRawTransactionSpy.mockImplementation((txid: string) => {
+      if (onChainTxids.has(txid)) {
+        return Promise.resolve(
+          {} as Awaited<ReturnType<BitcoinFaucet["getRawTransaction"]>>,
+        );
+      }
+      return Promise.reject(
+        new Error("No such mempool or blockchain transaction"),
+      );
+    });
+  };
+
+  const buildPackages = (leaf: TreeNode) =>
+    constructUnilateralExitFeeBumpPackages(
+      [bytesToHex(TreeNode.encode(leaf).finish())],
+      [fundingUtxo],
+      { satPerVbyte: 5 },
+      Network.LOCAL,
+    );
+
+  beforeEach(() => {
+    getRawTransactionSpy = jest.spyOn(
+      BitcoinFaucet.prototype,
+      "getRawTransaction",
+    );
+  });
+
+  afterEach(() => {
+    getRawTransactionSpy.mockRestore();
+  });
+
+  it("emits the leaf's node tx and refund when neither is on chain", async () => {
+    const leaf = makeLeaf("leaf-a", "aa".repeat(32));
+    setOnChainTxids(new Set());
+
+    expect.assertions(4);
+
+    const result = await buildPackages(leaf);
+
+    expect(result).toHaveLength(1);
+    const txPackages = result[0]!.txPackages;
+    expect(txPackages.map((pkg) => pkg.tx)).toEqual([
+      bytesToHex(leaf.nodeTx),
+      bytesToHex(leaf.refundTx),
+    ]);
+    for (const pkg of txPackages) {
+      expect(pkg.feeBumpPsbt).toBeDefined();
+    }
+  });
+
+  it("still surfaces the pending refund when the leaf's node tx is already on chain", async () => {
+    const leaf = makeLeaf("leaf-a", "aa".repeat(32));
+    setOnChainTxids(new Set([txidOf(leaf.nodeTx)]));
+
+    const result = await buildPackages(leaf);
+
+    expect(result).toHaveLength(1);
+    const txPackages = result[0]!.txPackages;
+    expect(txPackages.map((pkg) => pkg.tx)).toEqual([
+      bytesToHex(leaf.refundTx),
+    ]);
+    // The emitted refund must carry a well-formed fee bump so it can be
+    // broadcast once its CSV timelock matures.
+    btc.Transaction.fromPSBT(hexToBytes(txPackages[0]!.feeBumpPsbt!));
+  });
+
+  it("omits the refund once the refund itself is on chain", async () => {
+    const leaf = makeLeaf("leaf-a", "aa".repeat(32));
+    setOnChainTxids(new Set([txidOf(leaf.nodeTx), txidOf(leaf.refundTx)]));
+
+    const result = await buildPackages(leaf);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.txPackages).toHaveLength(0);
+  });
+
+  it.each([
+    ["directRefundTx", 2],
+    ["directFromCpfpRefundTx", 3],
+  ])(
+    "omits the refund when the leaf's %s is on chain",
+    async (directField, vout) => {
+      const leaf = TreeNode.fromPartial({
+        id: "leaf-a",
+        nodeTx: makeTrucParentBytes("aa".repeat(32), 0),
+        refundTx: makeTrucParentBytes("aa".repeat(32), 1),
+        [directField]: makeTrucParentBytes("aa".repeat(32), vout),
+        status: "AVAILABLE",
+      });
+      const onChainTxids = new Set([
+        txidOf(leaf.nodeTx),
+        txidOf(
+          directField === "directRefundTx"
+            ? leaf.directRefundTx
+            : leaf.directFromCpfpRefundTx,
+        ),
+      ]);
+      setOnChainTxids(onChainTxids);
+
+      const result = await buildPackages(leaf);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.txPackages).toHaveLength(0);
+    },
+  );
 });

--- a/sdks/js/packages/spark-sdk/src/utils/unilateral-exit.ts
+++ b/sdks/js/packages/spark-sdk/src/utils/unilateral-exit.ts
@@ -165,6 +165,42 @@ export async function buildUnilateralExitChain(
   return chain;
 }
 
+// A leaf's refund is still pending (and must be surfaced) until the refund
+// itself — or an equivalent direct variant, which is what a watchtower
+// broadcasts — is on chain. Unparseable variants are treated as not on chain
+// so we err on the side of emitting the refund rather than silently dropping
+// it.
+async function isRefundPending(
+  node: TreeNode,
+  network: Network,
+  logger?: Logger,
+): Promise<boolean> {
+  const variants: Array<{ label: string; bytes: Uint8Array }> = [
+    { label: "refundTx", bytes: node.refundTx },
+    { label: "directRefundTx", bytes: node.directRefundTx },
+    { label: "directFromCpfpRefundTx", bytes: node.directFromCpfpRefundTx },
+  ];
+
+  for (const { label, bytes } of variants) {
+    if (!bytes || bytes.length === 0) {
+      continue;
+    }
+    try {
+      const txid = getTxId(getTxFromRawTxHex(bytesToHex(bytes)));
+      if (await isTxBroadcast(txid, network)) {
+        return false;
+      }
+    } catch (error) {
+      warnUnilateralExit(
+        logger,
+        `unable to parse ${label} for broadcast check on node ${node.id}: ${formatErrorForLog(error)}. Treating the refund as still pending.`,
+      );
+    }
+  }
+
+  return true;
+}
+
 export function isEphemeralAnchorOutput(
   script?: Uint8Array,
   amount?: bigint,
@@ -289,19 +325,28 @@ export async function constructUnilateralExitFeeBumpPackages(
       // Add node tx and its fee bump
       const nodeTxHex = bytesToHex(chainNode.nodeTx);
 
+      // A unilateral exit is two-phase: the exit chain is broadcast first,
+      // then the leaf's CSV-timelocked refund once the timelock matures. The
+      // refund must keep surfacing until the refund (or an equivalent direct
+      // variant, which is what a watchtower broadcasts) is itself on chain,
+      // independent of whether the leaf's node tx has already been broadcast.
+      // Otherwise a stateless resume (rebuilding packages from chain state
+      // after the node tx confirmed) returns a package list with no refund
+      // and the leaf's value is left stranded in the timelock-encumbered node
+      // output.
+      const isLeafNode = chainNode.id === node.id;
+      let nodeTxBroadcast = false;
+
       // We skip tx's which have already been broadcasted, or we've seen in the past
       try {
         const txObj = getTxFromRawTxHex(nodeTxHex);
         const txid = getTxId(txObj);
         if (broadcastTxs.get(txid)) {
           // We already created a package for this node in another leaf.
-          continue;
-        }
-        broadcastTxs.set(txid, true);
-        const isBroadcast = await isTxBroadcast(txid, network);
-        if (isBroadcast) {
-          // This node has already been broadcast, so we don't need to do so.
-          continue;
+          nodeTxBroadcast = true;
+        } else {
+          broadcastTxs.set(txid, true);
+          nodeTxBroadcast = await isTxBroadcast(txid, network);
         }
       } catch (parseError) {
         warnUnilateralExit(
@@ -310,49 +355,52 @@ export async function constructUnilateralExitFeeBumpPackages(
         );
       }
 
-      const { feeBumpPsbt: nodeFeeBumpPsbt, usedUtxos } = constructFeeBumpTx(
-        nodeTxHex,
-        availableUtxos,
-        feeRate,
-        undefined,
-        logger,
-      );
-
-      const feeBumpTx = btc.Transaction.fromPSBT(hexToBytes(nodeFeeBumpPsbt));
-
-      // Get the fee bump transaction's output, if any
-      const feeBumpOut: psbt.TransactionOutput | null =
-        feeBumpTx.outputsLength === 1 ? feeBumpTx.getOutput(0) : null;
-      let feeBumpOutPubKey: string | null = null;
-
-      // Remove used UTXOs from the available list
-      for (const usedUtxo of usedUtxos) {
-        if (feeBumpOut && bytesToHex(feeBumpOut.script!) == usedUtxo.script) {
-          feeBumpOutPubKey = usedUtxo.publicKey;
-        }
-        const index = availableUtxos.findIndex(
-          (u) => u.txid === usedUtxo.txid && u.vout === usedUtxo.vout,
+      if (!nodeTxBroadcast) {
+        const { feeBumpPsbt: nodeFeeBumpPsbt, usedUtxos } = constructFeeBumpTx(
+          nodeTxHex,
+          availableUtxos,
+          feeRate,
+          undefined,
+          logger,
         );
-        if (index !== -1) {
-          availableUtxos.splice(index, 1);
+
+        const feeBumpTx = btc.Transaction.fromPSBT(hexToBytes(nodeFeeBumpPsbt));
+
+        // Get the fee bump transaction's output, if any
+        const feeBumpOut: psbt.TransactionOutput | null =
+          feeBumpTx.outputsLength === 1 ? feeBumpTx.getOutput(0) : null;
+        let feeBumpOutPubKey: string | null = null;
+
+        // Remove used UTXOs from the available list
+        for (const usedUtxo of usedUtxos) {
+          if (feeBumpOut && bytesToHex(feeBumpOut.script!) == usedUtxo.script) {
+            feeBumpOutPubKey = usedUtxo.publicKey;
+          }
+          const index = availableUtxos.findIndex(
+            (u) => u.txid === usedUtxo.txid && u.vout === usedUtxo.vout,
+          );
+          if (index !== -1) {
+            availableUtxos.splice(index, 1);
+          }
         }
+
+        // If the fee bump TX has an output, it should have the same key as the
+        // input. We can add the output to the beginning of the list.
+        if (feeBumpOut)
+          availableUtxos.unshift({
+            txid: getTxId(feeBumpTx),
+            vout: 0,
+            value: feeBumpOut.amount!,
+            script: bytesToHex(feeBumpOut.script!),
+            publicKey: feeBumpOutPubKey!,
+          });
+
+        txPackages.push({ tx: nodeTxHex, feeBumpPsbt: nodeFeeBumpPsbt });
       }
 
-      // If the fee bump TX has an output, it should have the same key as the
-      // input. We can add the output to the beginning of the list.
-      if (feeBumpOut)
-        availableUtxos.unshift({
-          txid: getTxId(feeBumpTx),
-          vout: 0,
-          value: feeBumpOut.amount!,
-          script: bytesToHex(feeBumpOut.script!),
-          publicKey: feeBumpOutPubKey!,
-        });
-
-      txPackages.push({ tx: nodeTxHex, feeBumpPsbt: nodeFeeBumpPsbt });
-
       // If this is the original node we started with, also add its refund tx
-      if (chainNode.id === node.id) {
+      // unless the refund (or an equivalent direct variant) is already on chain.
+      if (isLeafNode && (await isRefundPending(chainNode, network, logger))) {
         const refundTxHex = bytesToHex(chainNode.refundTx);
 
         const refundFeeBump = constructFeeBumpTx(


### PR DESCRIPTION
## Summary

Fixes #146.

`constructUnilateralExitFeeBumpPackages` emits a leaf's CSV-timelocked refund only in the same loop iteration that emits the leaf's own node tx — a step that is skipped once that node is on chain. A caller that rebuilds the packages from chain state on a later run (stateless resume) gets back a package list with **no refund**: no error is thrown, the exit reads as complete, and the leaf's value stays in the unspent, timelock-encumbered node output. It only surfaces in the operators-unavailable case (a genuine unilateral exit); on live networks it's masked by the operators' chainwatcher broadcasting the refund.

## Root cause

Inside the `for (const chainNode of chain)` loop, an already-broadcast node was skipped via `continue`, and the refund was emitted only for the original leaf node in a block *after* that skip:

```ts
const isBroadcast = await isTxBroadcast(txid, network);
if (isBroadcast) {
  continue; // ← fires once the leaf's node tx confirms...
}
// ...
// If this is the original node we started with, also add its refund tx
if (chainNode.id === node.id) { /* ...never reached again */ }
```

The refund is a separate transaction, only broadcastable after its CSV timelock matures, so once the `continue` fires it is never emitted again.

## Fix

Decouple refund emission from the node-broadcast skip:

- The broadcast/`continue` for the node tx is replaced with a `nodeTxBroadcast` flag; the node fee-bump package is still skipped when the node tx is already on chain (or was already packaged for another leaf), but the refund block is now reached regardless.
- The refund is gated by a new `isRefundPending` helper instead of by loop position: the refund is surfaced until the refund **or an equivalent direct variant** (`directRefundTx` / `directFromCpfpRefundTx`, which is what a watchtower broadcasts) is itself on chain. Unparseable variants are treated as pending, so the function errs toward emitting the refund rather than silently dropping it.

Net effect: node tx confirms → CSV matures → re-running the builder still produces the refund + fee bump until the refund itself lands on chain. No behavior change before the node tx is broadcast, or after the refund/variant confirms.

## Tests

New deterministic unit tests in `src/tests/unilateral-exit.test.ts` (`unilateral exit stateless resume`); no live Bitcoin network — `isTxBroadcast` on `Network.LOCAL` resolves through `BitcoinFaucet.getRawTransaction`, which the tests stub to simulate on-chain state:

- nothing on chain → packages are `[nodeTx, refundTx]`
- **node tx on chain, refund pending → packages are `[refundTx]`** (previously `[]` — the bug; this test fails without the fix)
- refund itself on chain → no packages
- `directRefundTx` / `directFromCpfpRefundTx` on chain → no packages (watchtower already swept)

## Verification

- New tests fail before the fix (the node-on-chain case returns `[]` instead of `[refundTx]`) and pass after.
- Full `spark-sdk` unit suite (`yarn test`): 62 suites pass; the only failure is `quote-envelope.test.ts`, which fails identically on unmodified HEAD (pre-existing, unrelated).
- `tsc --noEmit`, `eslint`, and `prettier --check` are clean on the changed files.
